### PR TITLE
feat(adapter-node): opt-in static-asset precompression

### DIFF
--- a/.changeset/precompress-static-assets.md
+++ b/.changeset/precompress-static-assets.md
@@ -1,0 +1,5 @@
+---
+"@universal-deploy/node": minor
+---
+
+feat(node): opt-in build-time precompression of static assets (`node({ precompress: true })`)

--- a/.changeset/precompress-static-assets.md
+++ b/.changeset/precompress-static-assets.md
@@ -1,5 +1,6 @@
 ---
 "@universal-deploy/node": minor
+"@universal-deploy/vite": minor
 ---
 
 feat(node): opt-in build-time precompression of static assets (`node({ precompress: true })`)

--- a/examples/app-node/playwright.config.ts
+++ b/examples/app-node/playwright.config.ts
@@ -1,4 +1,6 @@
-// This app opts into precompression, so the shared suite runs its precompression case here.
-process.env.UD_PRECOMPRESS = "1";
+import base from "@universal-deploy/e2e/config";
 
-export { default } from "@universal-deploy/e2e/config";
+// This app enables precompression, so the shared suite runs its precompression case here.
+const config: typeof base = { ...base, metadata: { ...base.metadata, precompress: true } };
+
+export default config;

--- a/examples/app-node/playwright.config.ts
+++ b/examples/app-node/playwright.config.ts
@@ -1,1 +1,4 @@
+// This app opts into precompression, so the shared suite runs its precompression case here.
+process.env.UD_PRECOMPRESS = "1";
+
 export { default } from "@universal-deploy/e2e/config";

--- a/examples/app-node/vite.config.ts
+++ b/examples/app-node/vite.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   plugins: [
     // Emits dist/index.js
-    node(),
+    node({ precompress: true }),
     // Minimal SSR framework. Includes devServer and catchAll plugins from universal-deploy
     awesomeFramework({
       additionalEntries: [

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -19,8 +19,8 @@ node({
 ```
 
 Eligible: `.css`, `.htm`, `.html`, `.js`, `.json`, `.mjs`, `.svg`, `.txt`, `.wasm` and `.xml`, at
-or above `threshold`, when the encoded form is no larger. Everything else is compressed per
-request, as before.
+or above `threshold`, when the encoded form is no larger. Everything else is left to srvx's own
+static handling, as before.
 
 Variants track their sources: a file that earns one has it, a file that no longer does has it
 removed, and a removal that fails stops the build. Files in `publicDir` are copied as-is: the build creates no
@@ -28,6 +28,6 @@ removed, and a removal that fails stops the build. Files in `publicDir` are copi
 in step with its source is yours.
 
 Not covered: a runtime `static` pointing anywhere other than the directory this build
-precompressed, and a client built separately without `precompress` — both fall back to
-per-request compression; and pages written by a pre-render step that runs no Vite build.
+precompressed, and a client built separately without `precompress` — both fall back to srvx's
+own static handling; and pages written by a pre-render step that runs no Vite build.
 Variants left behind by a removed encoding are never looked up.

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -19,9 +19,10 @@ node({
 Applies to `.css`, `.htm`, `.html`, `.js`, `.json`, `.mjs`, `.svg`, `.txt`, `.wasm` and `.xml`,
 and only when the encoded form is smaller. On-the-fly compression stays on for everything else.
 
-- **Stale variants are deleted.** If a file stops qualifying, the `.br`/`.gz` beside it is
-  removed — otherwise a rebuild with `emptyOutDir: false` would serve the previous build's
-  variant as the new file's body. One that cannot be deleted fails the build.
+- **Variants stay in sync with their sources.** Each build reconciles the `.br`/`.gz` beside
+  every file it visits: rewritten when the source changed, removed when the file no longer
+  qualifies. That is what keeps a rebuild into an existing directory from serving a previous
+  build's variant. If one cannot be removed, the build stops rather than leave it.
 - **`publicDir` files are yours.** Never compressed or cleaned up. A `.br` you ship in `public/`
   is still served; keeping it in step with its source is up to you.
 - **Runtime `static` wins.** Variant lookup is enabled only for the directory this build

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -23,8 +23,10 @@ or above `threshold`, when the encoded form is no larger. Everything else is com
 request, as before.
 
 Each build rewrites the variants it owns and deletes the ones a file no longer earns, so
-rebuilding into an existing directory cannot serve a previous build's bytes; a variant it cannot
-delete fails the build. Files in `publicDir` are yours — never compressed, never deleted.
+rebuilding into an existing directory cannot serve a stale variant it created; a variant it
+cannot delete fails the build. Files in `publicDir` are copied as-is: the build creates no
+`.br`/`.gz` for them and deletes none. A variant you ship beside one is still served — keeping it
+in step with its source is yours.
 
 Not covered: a runtime `static` pointing anywhere other than the directory this build
 precompressed, and a client built separately without `precompress` — both fall back to

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -1,1 +1,75 @@
 Wraps `@universal-deploy/store` entries with [srvx](https://srvx.h3.dev/) + [sirv](https://universal-middleware.dev/middlewares/sirv)
+
+## `precompress`
+
+Off by default. When enabled, `vite build` writes `.br`/`.gz` variants beside the eligible
+static assets, and the generated server serves those files instead of compressing on every
+request.
+
+```ts
+import { node } from "@universal-deploy/node/vite";
+
+export default {
+  plugins: [node({ precompress: true })],
+};
+```
+
+```ts
+node({
+  precompress: {
+    // Emitted in server-preference order: the first one the client accepts wins.
+    encodings: ["br", "gzip"], // default
+    // Minimum size of the original file, in bytes. No upper bound — precompression is
+    // the only way to compress a file past srvx's 10 MiB on-the-fly ceiling.
+    threshold: 1024, // default
+  },
+});
+```
+
+Variants are emitted for the extensions srvx negotiates an encoding for — `.css`, `.htm`,
+`.html`, `.js`, `.json`, `.mjs`, `.svg`, `.txt`, `.wasm`, `.xml` — and only when the encoded
+form is actually smaller. Files below `threshold`, already-compressed formats, and anything
+srvx would not negotiate are skipped, because a variant it never looks for is dead bytes on
+disk.
+
+On-the-fly compression stays enabled either way. It still covers files below the threshold,
+extensions outside that set, and anything this build did not produce.
+
+### It deletes variants it did not write
+
+For each file it visits, the precompressor owns the variants for **the encodings this build
+emits**. If a file stops qualifying — its content changed, it dropped below the threshold, or
+it stopped compressing well — the matching `.br`/`.gz` beside it is **deleted**. Without that,
+a rebuild into a non-empty output directory (`emptyOutDir: false`) would leave the previous
+build's variant next to the new file, and it would be served as that file's body.
+
+If a variant cannot be removed, the build fails rather than continuing: a leftover that could
+not be deleted is exactly the case that serves wrong bytes.
+
+Files copied from `publicDir` are left alone entirely — neither compressed nor cleaned up.
+They are re-copied from source on every build, so this build's output can never go stale
+beside them. A `.br` you ship yourself in `public/` is still served by srvx once `precompress`
+is on; keeping it in step with its source file is yours to manage.
+
+### Leftovers when it is off, or when an encoding is dropped
+
+Both are inert, and neither needs cleaning up. srvx only looks for a variant when the server
+was built with `precompress` on, and only for the encodings that build emitted. A `.gz` left
+behind after dropping `"gzip"` is never probed; re-enable it and the next build reconciles it.
+
+### Overriding the static directory at runtime
+
+A server entry's own `static` value wins over the build-time one. Variant lookup is enabled
+**only for the directory this build precompressed**: point `static` at a *different* resolved
+directory and the server falls back to on-the-fly compression rather than trusting variants
+nothing reconciled. The same resolved directory keeps it. Two spellings of one directory —
+Windows case differences, a symlink, a junction — compare unequal and conservatively lose the
+optimization; they never risk serving the wrong bytes.
+
+Deploying a server built with `precompress: true` in front of assets built without it has the
+same effect and is not something the server can detect. Build both halves together.
+
+### Not covered
+
+Pages rendered by a framework's pre-render step, which writes into the output directory after
+the build hooks have run, get no variants.

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -26,7 +26,7 @@ and only when the encoded form is smaller. On-the-fly compression stays on for e
   is still served; keeping it in step with its source is up to you.
 - **Runtime `static` wins.** Variant lookup is enabled only for the directory this build
   precompressed; a different resolved directory falls back to on-the-fly compression.
-- **Not covered:** pages written by a framework's pre-render step, which runs after the build
-  hooks; and assets built without `precompress` behind a server built with it — build both
-  together. Leftovers from a disabled option or a dropped encoding are never probed, so they
-  are inert.
+- **Not covered:** pages produced by a separate pre-render run (`$ vike prerender`), which
+  starts no Vite build; and assets built without `precompress` behind a server built with it —
+  build both together. Leftovers from a disabled option or a dropped encoding are never probed,
+  so they are inert.

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -22,8 +22,7 @@ Eligible: `.css`, `.htm`, `.html`, `.js`, `.json`, `.mjs`, `.svg`, `.txt`, `.was
 or above `threshold`, when the encoded form is no larger. Everything else is compressed per
 request, as before.
 
-Each build verifies or rewrites the variants it owns and deletes the ones a file no longer earns, so
-rebuilding into an existing directory cannot serve a stale variant it created; a variant it
+Each build writes the variants a file earns and deletes the ones it no longer earns; a variant it
 cannot delete fails the build. Files in `publicDir` are copied as-is: the build creates no
 `.br`/`.gz` for them and deletes none. A variant you ship beside one is still served — keeping it
 in step with its source is yours.

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -22,8 +22,8 @@ Eligible: `.css`, `.htm`, `.html`, `.js`, `.json`, `.mjs`, `.svg`, `.txt`, `.was
 or above `threshold`, when the encoded form is no larger. Everything else is compressed per
 request, as before.
 
-Each build writes the variants a file earns and deletes the ones it no longer earns; a variant it
-cannot delete fails the build. Files in `publicDir` are copied as-is: the build creates no
+Variants track their sources: a file that earns one has it, a file that no longer does has it
+removed, and a removal that fails stops the build. Files in `publicDir` are copied as-is: the build creates no
 `.br`/`.gz` for them and deletes none. A variant you ship beside one is still served — keeping it
 in step with its source is yours.
 

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -2,74 +2,31 @@ Wraps `@universal-deploy/store` entries with [srvx](https://srvx.h3.dev/) + [sir
 
 ## `precompress`
 
-Off by default. When enabled, `vite build` writes `.br`/`.gz` variants beside the eligible
-static assets, and the generated server serves those files instead of compressing on every
-request.
+Off by default. Emits `.br`/`.gz` beside eligible static assets at build time and serves those
+files instead of compressing on every request.
 
 ```ts
-import { node } from "@universal-deploy/node/vite";
-
-export default {
-  plugins: [node({ precompress: true })],
-};
-```
-
-```ts
+node({ precompress: true })
+// or, with the defaults spelled out:
 node({
   precompress: {
-    // Emitted in server-preference order: the first one the client accepts wins.
-    encodings: ["br", "gzip"], // default
-    // Minimum size of the original file, in bytes. No upper bound — precompression is
-    // the only way to compress a file past srvx's 10 MiB on-the-fly ceiling.
-    threshold: 1024, // default
+    encodings: ["br", "gzip"], // the first one the client accepts wins
+    threshold: 1024, // minimum size of the original file, in bytes
   },
-});
+})
 ```
 
-Variants are emitted for the extensions srvx negotiates an encoding for — `.css`, `.htm`,
-`.html`, `.js`, `.json`, `.mjs`, `.svg`, `.txt`, `.wasm`, `.xml` — and only when the encoded
-form is actually smaller. Files below `threshold`, already-compressed formats, and anything
-srvx would not negotiate are skipped, because a variant it never looks for is dead bytes on
-disk.
+Applies to `.css`, `.htm`, `.html`, `.js`, `.json`, `.mjs`, `.svg`, `.txt`, `.wasm` and `.xml`,
+and only when the encoded form is smaller. On-the-fly compression stays on for everything else.
 
-On-the-fly compression stays enabled either way. It still covers files below the threshold,
-extensions outside that set, and anything this build did not produce.
-
-### It deletes variants it did not write
-
-For each file it visits, the precompressor owns the variants for **the encodings this build
-emits**. If a file stops qualifying — its content changed, it dropped below the threshold, or
-it stopped compressing well — the matching `.br`/`.gz` beside it is **deleted**. Without that,
-a rebuild into a non-empty output directory (`emptyOutDir: false`) would leave the previous
-build's variant next to the new file, and it would be served as that file's body.
-
-If a variant cannot be removed, the build fails rather than continuing: a leftover that could
-not be deleted is exactly the case that serves wrong bytes.
-
-Files copied from `publicDir` are left alone entirely — neither compressed nor cleaned up.
-They are re-copied from source on every build, so this build's output can never go stale
-beside them. A `.br` you ship yourself in `public/` is still served by srvx once `precompress`
-is on; keeping it in step with its source file is yours to manage.
-
-### Leftovers when it is off, or when an encoding is dropped
-
-Both are inert, and neither needs cleaning up. srvx only looks for a variant when the server
-was built with `precompress` on, and only for the encodings that build emitted. A `.gz` left
-behind after dropping `"gzip"` is never probed; re-enable it and the next build reconciles it.
-
-### Overriding the static directory at runtime
-
-A server entry's own `static` value wins over the build-time one. Variant lookup is enabled
-**only for the directory this build precompressed**: point `static` at a *different* resolved
-directory and the server falls back to on-the-fly compression rather than trusting variants
-nothing reconciled. The same resolved directory keeps it. Two spellings of one directory —
-Windows case differences, a symlink, a junction — compare unequal and conservatively lose the
-optimization; they never risk serving the wrong bytes.
-
-Deploying a server built with `precompress: true` in front of assets built without it has the
-same effect and is not something the server can detect. Build both halves together.
-
-### Not covered
-
-Pages rendered by a framework's pre-render step, which writes into the output directory after
-the build hooks have run, get no variants.
+- **Stale variants are deleted.** If a file stops qualifying, the `.br`/`.gz` beside it is
+  removed — otherwise a rebuild with `emptyOutDir: false` would serve the previous build's
+  variant as the new file's body. One that cannot be deleted fails the build.
+- **`publicDir` files are yours.** Never compressed or cleaned up. A `.br` you ship in `public/`
+  is still served; keeping it in step with its source is up to you.
+- **Runtime `static` wins.** Variant lookup is enabled only for the directory this build
+  precompressed; a different resolved directory falls back to on-the-fly compression.
+- **Not covered:** pages written by a framework's pre-render step, which runs after the build
+  hooks; and assets built without `precompress` behind a server built with it — build both
+  together. Leftovers from a disabled option or a dropped encoding are never probed, so they
+  are inert.

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -18,20 +18,15 @@ node({
 })
 ```
 
-Applies to `.css`, `.htm`, `.html`, `.js`, `.json`, `.mjs`, `.svg`, `.txt`, `.wasm` and `.xml`,
-and only when the encoded form is no larger than the original. On-the-fly compression
-stays on for everything else.
+Eligible: `.css`, `.htm`, `.html`, `.js`, `.json`, `.mjs`, `.svg`, `.txt`, `.wasm` and `.xml`, at
+or above `threshold`, when the encoded form is no larger. Everything else is compressed per
+request, as before.
 
-- **Variants stay in sync with their sources.** For the extensions above, and for the
-  encodings you configured, each build rewrites the `.br`/`.gz` when the source changed and
-  removes it when the file no longer qualifies. That is what keeps a rebuild into an existing
-  directory from serving a previous build's variant. If one cannot be removed, the build stops
-  rather than leave it. Other extensions, other encodings, and `publicDir` files are untouched.
-- **`publicDir` files are yours.** Never compressed or cleaned up. A `.br` you ship in `public/`
-  is still served; keeping it in step with its source is up to you.
-- **Runtime `static` wins.** Variant lookup is enabled only for the directory this build
-  precompressed; a different resolved directory falls back to on-the-fly compression.
-- **Not covered:** pages produced by a separate pre-render run (`$ vike prerender`), which
-  starts no Vite build; and assets built without `precompress` behind a server built with it —
-  build both together. Leftovers from a disabled option or a dropped encoding are never probed,
-  so they are inert.
+Each build rewrites the variants it owns and deletes the ones a file no longer earns, so
+rebuilding into an existing directory cannot serve a previous build's bytes; a variant it cannot
+delete fails the build. Files in `publicDir` are yours — never compressed, never deleted.
+
+Not covered: a runtime `static` pointing anywhere other than the directory this build
+precompressed, and a client built separately without `precompress` — both fall back to
+per-request compression; and pages written by a pre-render step that runs no Vite build.
+Variants left behind by a removed encoding are never looked up.

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -22,7 +22,7 @@ Eligible: `.css`, `.htm`, `.html`, `.js`, `.json`, `.mjs`, `.svg`, `.txt`, `.was
 or above `threshold`, when the encoded form is no larger. Everything else is compressed per
 request, as before.
 
-Each build rewrites the variants it owns and deletes the ones a file no longer earns, so
+Each build verifies or rewrites the variants it owns and deletes the ones a file no longer earns, so
 rebuilding into an existing directory cannot serve a stale variant it created; a variant it
 cannot delete fails the build. Files in `publicDir` are copied as-is: the build creates no
 `.br`/`.gz` for them and deletes none. A variant you ship beside one is still served — keeping it

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -1,4 +1,4 @@
-Wraps `@universal-deploy/store` entries with [srvx](https://srvx.h3.dev/) + [sirv](https://universal-middleware.dev/middlewares/sirv)
+Wraps `@universal-deploy/store` entries with [srvx](https://srvx.h3.dev/).
 
 ## `precompress`
 
@@ -6,6 +6,8 @@ Off by default. Emits `.br`/`.gz` beside eligible static assets at build time an
 files instead of compressing on every request.
 
 ```ts
+import { node } from "@universal-deploy/node/vite";
+
 node({ precompress: true })
 // or, with the defaults spelled out:
 node({
@@ -17,12 +19,14 @@ node({
 ```
 
 Applies to `.css`, `.htm`, `.html`, `.js`, `.json`, `.mjs`, `.svg`, `.txt`, `.wasm` and `.xml`,
-and only when the encoded form is smaller. On-the-fly compression stays on for everything else.
+and only when the encoded form is no larger than the original. On-the-fly compression
+stays on for everything else.
 
-- **Variants stay in sync with their sources.** Each build reconciles the `.br`/`.gz` beside
-  every file it visits: rewritten when the source changed, removed when the file no longer
-  qualifies. That is what keeps a rebuild into an existing directory from serving a previous
-  build's variant. If one cannot be removed, the build stops rather than leave it.
+- **Variants stay in sync with their sources.** For the extensions above, and for the
+  encodings you configured, each build rewrites the `.br`/`.gz` when the source changed and
+  removes it when the file no longer qualifies. That is what keeps a rebuild into an existing
+  directory from serving a previous build's variant. If one cannot be removed, the build stops
+  rather than leave it. Other extensions, other encodings, and `publicDir` files are untouched.
 - **`publicDir` files are yours.** Never compressed or cleaned up. A `.br` you ship in `public/`
   is still served; keeping it in step with its source is up to you.
 - **Runtime `static` wins.** Variant lookup is enabled only for the directory this build

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -148,57 +148,6 @@ describe("repeat passes over one directory", () => {
     expect((await stat(join(dir, "app.js.br"))).mtimeMs).toBe(backdated);
   });
 
-  it("repairs a variant altered between passes", async () => {
-    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
-    await precompressDir(dir, ALL);
-    // srvx serves whatever sits beside the identity without comparing it, so bytes that are
-    // not ours are wrong bytes on a live URL. Recording that we wrote here is not evidence
-    // that what is here now is what we wrote.
-    await writeFile(join(dir, "app.js.br"), Buffer.from("not brotli"));
-    const second = await precompressDir(dir, ALL);
-    expect(second.written).toBe(2);
-    expect(brotliDecompressSync(await readFile(join(dir, "app.js.br"))).toString()).toBe(COMPRESSIBLE);
-  });
-
-  it("removes a variant planted beside bytes that earned none", async () => {
-    await writeFile(join(dir, "blob.wasm"), incompressible(2048));
-    const first = await precompressDir(dir, ALL);
-    expect(first.written).toBe(0);
-    // The empty record is the case a presence check answers vacuously: there is nothing to
-    // find present, so only proving absence catches this.
-    await writeFile(join(dir, "blob.wasm.br"), Buffer.from("planted"));
-    await precompressDir(dir, ALL);
-    expect(await exists(join(dir, "blob.wasm.br"))).toBe(false);
-  });
-
-  it("verifies the variants a file earned and the absence of the ones it did not", async () => {
-    // brotli keeps this (its static dictionary catches the prefix); gzip comes out larger and
-    // is retired. Both halves of the record are then live at once.
-    const partial = Buffer.concat([
-      Buffer.from('<!DOCTYPE html><html><head><meta charset="utf-8"><title>'),
-      incompressible(1024),
-    ]);
-    await writeFile(join(dir, "page.html"), partial);
-    await precompressDir(dir, ALL);
-    expect(await exists(join(dir, "page.html.br"))).toBe(true);
-    expect(await exists(join(dir, "page.html.gz"))).toBe(false);
-
-    await writeFile(join(dir, "page.html.gz"), Buffer.from("planted"));
-    await precompressDir(dir, ALL);
-    expect(await exists(join(dir, "page.html.gz"))).toBe(false);
-    expect(brotliDecompressSync(await readFile(join(dir, "page.html.br")))).toEqual(partial);
-  });
-
-  it("stops the build when a variant cannot be read, rather than calling it absent", async () => {
-    await writeFile(join(dir, "blob.wasm"), incompressible(2048));
-    await precompressDir(dir, ALL);
-    // Unreadable for a reason that is not ENOENT. Treating it as absent would satisfy the
-    // absence proof vacuously and skip — which is the fail-open class U5c closed once already.
-    await mkdir(join(dir, "blob.wasm.br"));
-    await writeFile(join(dir, "blob.wasm.br", "blocker.txt"), "not a variant");
-    await expect(precompressDir(dir, ALL)).rejects.toThrow();
-  });
-
   it("a pass configured with more encodings does not hit an earlier pass's memo", async () => {
     const brOnly = resolvePrecompress({ encodings: ["br"] }) as ResolvedPrecompress;
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
@@ -210,16 +159,22 @@ describe("repeat passes over one directory", () => {
     expect(await exists(join(dir, "app.js.gz"))).toBe(true);
   });
 
-  it("re-emits when the variants were deleted after the pass that wrote them", async () => {
+  it("emits again for a second build in the same process", async () => {
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
-    await precompressDir(dir, ALL);
-    // A cleaned output directory, or a second build in the same process: the memo still
-    // holds these bytes, so only checking the variants are there catches it.
-    await rm(join(dir, "app.js.br"));
-    await rm(join(dir, "app.js.gz"));
+    const first = await precompressDir(dir, ALL);
+    expect(first.written).toBe(2);
+
+    // What `vite build --watch` does: empty the output directory, then rebuild byte-identical
+    // sources. The memo still holds those bytes, so a record that does not check its variants
+    // are on disk skips the whole tree and the build emits nothing at all.
+    await rm(dir, { recursive: true, force: true });
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+
     const second = await precompressDir(dir, ALL);
     expect(second.written).toBe(2);
     expect(await exists(join(dir, "app.js.br"))).toBe(true);
+    expect(await exists(join(dir, "app.js.gz"))).toBe(true);
   });
 
   it("a file written between passes is still covered", async () => {

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -6,13 +6,7 @@ import { brotliCompressSync, brotliDecompressSync, gunzipSync } from "node:zlib"
 import { staticMiddleware } from "srvx/static";
 import type { Environment } from "vite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  encodingsMap,
-  forgetReconciled,
-  precompressDir,
-  type ResolvedPrecompress,
-  resolvePrecompress,
-} from "./precompress.js";
+import { encodingsMap, precompressDir, type ResolvedPrecompress, resolvePrecompress } from "./precompress.js";
 import { type ResolvedStaticOptions, resolveStaticOptions } from "./static-options.js";
 import { node, resolveStaticDir, resolveStaticHint } from "./vite.js";
 
@@ -169,26 +163,6 @@ describe("repeat passes over one directory", () => {
     // Same bytes, so the digest matches; only the recorded configuration separates them.
     const second = await precompressDir(dir, ALL);
     expect(second.written).toBe(2);
-    expect(await exists(join(dir, "app.js.gz"))).toBe(true);
-  });
-
-  it("emits again for a second build in the same process", async () => {
-    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
-    const first = await precompressDir(dir, ALL);
-    expect(first.written).toBe(2);
-
-    // Models a second `vite.build()` in one process, where the output directory was emptied and
-    // byte-identical sources rebuilt. The sources are back and their digests still match, while
-    // the variants beside them are gone — so without the reset the whole tree is skipped and
-    // nothing is emitted.
-    await rm(dir, { recursive: true, force: true });
-    await mkdir(dir, { recursive: true });
-    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
-    forgetReconciled();
-
-    const second = await precompressDir(dir, ALL);
-    expect(second.written).toBe(2);
-    expect(await exists(join(dir, "app.js.br"))).toBe(true);
     expect(await exists(join(dir, "app.js.gz"))).toBe(true);
   });
 
@@ -391,7 +365,6 @@ describe("lookup is enabled only for the reconciled directory", () => {
 describe("the emission pass sees everything the build wrote", () => {
   interface PrecompressPlugin {
     applyToEnvironment?: unknown;
-    configResolved: () => void;
     closeBundle: { order?: string; handler: (this: unknown) => Promise<void> };
   }
 
@@ -426,25 +399,6 @@ describe("the emission pass sees everything the build wrote", () => {
     await plugin().closeBundle.handler.call(dispatch(dir));
     // vike writes pre-rendered HTML from the ssr environment. Nothing else walks after it.
     expect(await exists(join(dir, "prerendered.html.br"))).toBe(true);
-  });
-
-  it("a second build through the plugin emits again, with no reset from the test", async () => {
-    const p = plugin();
-    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
-    await p.closeBundle.handler.call(dispatch(dir));
-    expect(await exists(join(dir, "app.js.br"))).toBe(true);
-
-    // Models a second `vite.build()` that emptied the output directory and rebuilt identical sources.
-    // The reset has to come from the plugin's own `configResolved` — this test never calls
-    // `forgetReconciled`, so a record surviving the build boundary skips the whole tree.
-    await rm(dir, { recursive: true, force: true });
-    await mkdir(dir, { recursive: true });
-    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
-
-    p.configResolved();
-    await p.closeBundle.handler.call(dispatch(dir));
-    expect(await exists(join(dir, "app.js.br"))).toBe(true);
-    expect(await exists(join(dir, "app.js.gz"))).toBe(true);
   });
 
   it("declares no applyToEnvironment, so Vite dispatches it to all of them", () => {

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -229,6 +229,15 @@ describe("repeat passes over one directory", () => {
     expect(await exists(join(dir, "tiny.js.br"))).toBe(false);
   });
 
+  it("a repeated encoding is emitted once", async () => {
+    const duplicated = resolvePrecompress({ encodings: ["br", "br"] }) as ResolvedPrecompress;
+    expect(duplicated.encodings).toEqual(["br"]);
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    const { written } = await precompressDir(dir, duplicated);
+    expect(written).toBe(1);
+    expect(Object.keys(encodingsMap(duplicated))).toEqual(["br"]);
+  });
+
   it("the reported count matches the variants actually written", async () => {
     for (let i = 0; i < 10; i++) {
       await writeFile(join(dir, `f${i}.js`), `${COMPRESSIBLE}// ${i}\n`);
@@ -281,7 +290,9 @@ describe("F3 retire", () => {
     // A directory where a variant would be retired: non-recursive rm rejects.
     await mkdir(join(dir, "app.js.br"));
     await writeFile(join(dir, "app.js.br", "blocker.txt"), "blocks rm");
-    await expect(precompressDir(dir, ALL)).rejects.toThrow(/could not remove/);
+    // The build must stop: a variant that cannot be removed would be served as this
+    // file's body. The rejection is Node's own; the product promise is that it propagates.
+    await expect(precompressDir(dir, ALL)).rejects.toThrow();
   });
 });
 

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -132,14 +132,20 @@ describe("repeat passes over one directory", () => {
   it("a second pass does no work — emission runs once per environment", async () => {
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
     const first = await precompressDir(dir, ALL);
-    // Backdate the variant to a sentinel far outside timer resolution: a rewrite would
-    // replace it with "now", so its survival is unambiguous evidence of no rewrite.
+    // Backdate the variant far outside timer resolution, then read back what the filesystem
+    // actually stored — comparing that to a clock reading would assert a conversion, not the
+    // property. A rewrite replaces it with "now", a minute away from any granularity.
+    const fresh = (await stat(join(dir, "app.js.br"))).mtimeMs;
     const sentinel = new Date(Date.now() - 60_000);
     await utimes(join(dir, "app.js.br"), sentinel, sentinel);
+    const backdated = (await stat(join(dir, "app.js.br"))).mtimeMs;
+    // The margin everything below rests on. Had `utimes` not taken, `backdated` would be
+    // the first pass's own mtime and a rewrite inside granularity would compare equal.
+    expect(fresh - backdated).toBeGreaterThan(30_000);
     const second = await precompressDir(dir, ALL);
     expect(first.written).toBe(2);
     expect(second.written).toBe(0);
-    expect((await stat(join(dir, "app.js.br"))).mtimeMs).toBe(sentinel.getTime());
+    expect((await stat(join(dir, "app.js.br"))).mtimeMs).toBe(backdated);
   });
 
   it("a file written between passes is still covered", async () => {

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -164,9 +164,9 @@ describe("repeat passes over one directory", () => {
     const first = await precompressDir(dir, ALL);
     expect(first.written).toBe(2);
 
-    // What `vite build --watch` does: empty the output directory, then rebuild byte-identical
-    // sources. The memo still holds those bytes, so a record that does not check its variants
-    // are on disk skips the whole tree and the build emits nothing at all.
+    // What a second `vite.build()` in one process does: empty the output directory, then rebuild
+    // byte-identical sources. The memo still holds those bytes, so a record that does not check
+    // its variants are on disk skips the whole tree and the build emits nothing at all.
     await rm(dir, { recursive: true, force: true });
     await mkdir(dir, { recursive: true });
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -148,33 +148,32 @@ describe("repeat passes over one directory", () => {
     expect((await stat(join(dir, "app.js.br"))).mtimeMs).toBe(backdated);
   });
 
-  it("a later pass over unchanged bytes never reads the variants", async () => {
+  it("repairs a variant altered between passes", async () => {
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
     await precompressDir(dir, ALL);
-    // Corrupt the variant. Decoding it would fail and force a rewrite, so its survival is
-    // what proves the second pass skipped on the memo instead of reading anything.
+    // srvx serves whatever sits beside the identity without comparing it, so bytes that are
+    // not ours are wrong bytes on a live URL. Recording that we wrote here is not evidence
+    // that what is here now is what we wrote.
     await writeFile(join(dir, "app.js.br"), Buffer.from("not brotli"));
     const second = await precompressDir(dir, ALL);
-    expect(second.written).toBe(0);
-    expect((await readFile(join(dir, "app.js.br"))).toString()).toBe("not brotli");
+    expect(second.written).toBe(2);
+    expect(brotliDecompressSync(await readFile(join(dir, "app.js.br"))).toString()).toBe(COMPRESSIBLE);
   });
 
-  it("a later pass re-encodes nothing for bytes that earned no variant", async () => {
+  it("removes a variant planted beside bytes that earned none", async () => {
     await writeFile(join(dir, "blob.wasm"), incompressible(2048));
     const first = await precompressDir(dir, ALL);
     expect(first.written).toBe(0);
-    // Nothing on disk to check, so only the memo can make this a skip. Planting variants the
-    // pass did not write proves it: a second pass leaves them exactly as found.
+    // The empty record is the case a presence check answers vacuously: there is nothing to
+    // find present, so only proving absence catches this.
     await writeFile(join(dir, "blob.wasm.br"), Buffer.from("planted"));
-    const second = await precompressDir(dir, ALL);
-    expect(second.written).toBe(0);
-    expect((await readFile(join(dir, "blob.wasm.br"))).toString()).toBe("planted");
+    await precompressDir(dir, ALL);
+    expect(await exists(join(dir, "blob.wasm.br"))).toBe(false);
   });
 
-  it("skips on the variants a file actually earned, not the ones configured", async () => {
+  it("verifies the variants a file earned and the absence of the ones it did not", async () => {
     // brotli keeps this (its static dictionary catches the prefix); gzip comes out larger and
-    // is retired. The memo must then check `.br` alone — checking `.gz` too would find it
-    // missing and re-encode both on every later pass.
+    // is retired. Both halves of the record are then live at once.
     const partial = Buffer.concat([
       Buffer.from('<!DOCTYPE html><html><head><meta charset="utf-8"><title>'),
       incompressible(1024),
@@ -184,10 +183,20 @@ describe("repeat passes over one directory", () => {
     expect(await exists(join(dir, "page.html.br"))).toBe(true);
     expect(await exists(join(dir, "page.html.gz"))).toBe(false);
 
-    await writeFile(join(dir, "page.html.br"), Buffer.from("planted"));
-    const second = await precompressDir(dir, ALL);
-    expect(second.written).toBe(0);
-    expect((await readFile(join(dir, "page.html.br"))).toString()).toBe("planted");
+    await writeFile(join(dir, "page.html.gz"), Buffer.from("planted"));
+    await precompressDir(dir, ALL);
+    expect(await exists(join(dir, "page.html.gz"))).toBe(false);
+    expect(brotliDecompressSync(await readFile(join(dir, "page.html.br")))).toEqual(partial);
+  });
+
+  it("stops the build when a variant cannot be read, rather than calling it absent", async () => {
+    await writeFile(join(dir, "blob.wasm"), incompressible(2048));
+    await precompressDir(dir, ALL);
+    // Unreadable for a reason that is not ENOENT. Treating it as absent would satisfy the
+    // absence proof vacuously and skip — which is the fail-open class U5c closed once already.
+    await mkdir(join(dir, "blob.wasm.br"));
+    await writeFile(join(dir, "blob.wasm.br", "blocker.txt"), "not a variant");
+    await expect(precompressDir(dir, ALL)).rejects.toThrow();
   });
 
   it("a pass configured with more encodings does not hit an earlier pass's memo", async () => {

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -170,9 +170,9 @@ describe("repeat passes over one directory", () => {
     const first = await precompressDir(dir, ALL);
     expect(first.written).toBe(2);
 
-    // What a second `vite.build()` in one process does: empty the output directory, then rebuild
-    // byte-identical sources. The record describes files that are now gone, so without the reset
-    // the digests still match and the whole tree is skipped — the build emits nothing at all.
+    // A second `vite.build()` in one process, where the output directory was emptied and
+    // byte-identical sources rebuilt. The record describes files that are now gone, so without
+    // the reset the digests still match and the whole tree is skipped — nothing is emitted.
     await rm(dir, { recursive: true, force: true });
     await mkdir(dir, { recursive: true });
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
@@ -416,7 +416,7 @@ describe("the emission pass sees everything the build wrote", () => {
     await p.closeBundle.handler.call(dispatch(dir));
     expect(await exists(join(dir, "app.js.br"))).toBe(true);
 
-    // A second `vite.build()`: the output directory is emptied and identical sources rebuilt.
+    // A second `vite.build()` that emptied the output directory and rebuilt identical sources.
     // The reset has to come from the plugin's own `configResolved` — this test never calls
     // `forgetReconciled`, so a record surviving the build boundary skips the whole tree.
     await rm(dir, { recursive: true, force: true });

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -1,6 +1,13 @@
-import { resolve } from "node:path";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { brotliDecompressSync, gunzipSync } from "node:zlib";
+import { staticMiddleware } from "srvx/static";
 import type { Environment } from "vite";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { encodingsMap, precompressDir, type ResolvedPrecompress, resolvePrecompress } from "./precompress.js";
+import { type ResolvedStaticOptions, resolveStaticOptions } from "./static-options.js";
 import { resolveStaticDir, resolveStaticHint } from "./vite.js";
 
 /**
@@ -91,5 +98,263 @@ describe("walker and server agree on one directory", () => {
     const env = makeEnv({ root: ROOT, serverOutDir: "dist/server" });
     const hint = resolveStaticHint(env, abs);
     expect(resolve("/somewhere/else/entirely", hint as string)).toBe(resolveStaticDir(env, abs));
+  });
+});
+
+// ── emission, serving, and the F3 retire mechanism ──────────────────────────────
+
+/**
+ * Deterministic bytes that neither encoder can shrink — a SHA-256 chain, so no
+ * `Math.random` and no fixture file. Measured: brotli q11 and gzip 9 both come out
+ * larger than the input. (A linear generator is not enough; its output still
+ * compresses by roughly a third.)
+ */
+function incompressible(length: number): Buffer {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  let block = Buffer.from("ud-precompress");
+  while (total < length) {
+    block = createHash("sha256").update(block).digest();
+    chunks.push(block);
+    total += block.length;
+  }
+  return Buffer.concat(chunks, length);
+}
+
+/** Compresses well and is comfortably over the default threshold. */
+const COMPRESSIBLE = `export const greeting = ${JSON.stringify("hello ".repeat(900))};\n`;
+
+const ALL = resolvePrecompress(true) as ResolvedPrecompress;
+
+let dir: string;
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "ud-precompress-"));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+const exists = (path: string) =>
+  stat(path).then(
+    () => true,
+    () => false,
+  );
+
+async function request(options: ResolvedStaticOptions, encoding: string) {
+  const middleware = staticMiddleware(options);
+  return middleware(
+    new Request("http://x/app.js", { headers: { "accept-encoding": encoding } }),
+    () => new Response(null, { status: 404 }),
+  );
+}
+
+describe("precompress emission", () => {
+  it("A1 emits a variant smaller than its identity (emission only, not proof of serving)", async () => {
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await precompressDir(dir, ALL);
+    const identity = await stat(join(dir, "app.js"));
+    const variant = await stat(join(dir, "app.js.br"));
+    expect(variant.size).toBeLessThan(identity.size);
+  });
+
+  it("A2 skips an extension srvx never negotiates", async () => {
+    await writeFile(join(dir, "app.js.map"), COMPRESSIBLE);
+    await precompressDir(dir, ALL);
+    expect(await exists(join(dir, "app.js.map.br"))).toBe(false);
+  });
+
+  it("A3 skips an eligible, above-threshold file whose encoding is not smaller", async () => {
+    const noise = incompressible(2048);
+    await writeFile(join(dir, "noise.txt"), noise);
+    expect(noise.byteLength).toBeGreaterThan(ALL.threshold);
+    await precompressDir(dir, ALL);
+    expect(await exists(join(dir, "noise.txt.br"))).toBe(false);
+    expect(await exists(join(dir, "noise.txt.gz"))).toBe(false);
+  });
+
+  it("A3b skips a file under the threshold", async () => {
+    await writeFile(join(dir, "tiny.js"), "export const a = 1;\n");
+    await precompressDir(dir, ALL);
+    expect(await exists(join(dir, "tiny.js.br"))).toBe(false);
+  });
+});
+
+describe("A4 encodings order and selection", () => {
+  it("emits only the configured encoding and bakes only its suffix", async () => {
+    const gzipOnly = resolvePrecompress({ encodings: ["gzip"] }) as ResolvedPrecompress;
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await precompressDir(dir, gzipOnly);
+    expect(encodingsMap(gzipOnly)).toEqual({ gzip: ".gz" });
+    expect(await exists(join(dir, "app.js.gz"))).toBe(true);
+    expect(await exists(join(dir, "app.js.br"))).toBe(false);
+  });
+
+  it("map insertion order beats the client Accept-Encoding order", async () => {
+    const gzipFirst = resolvePrecompress({ encodings: ["gzip", "br"] }) as ResolvedPrecompress;
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await precompressDir(dir, gzipFirst);
+    expect(Object.keys(encodingsMap(gzipFirst))).toEqual(["gzip", "br"]);
+    const response = await request({ dir, encodings: encodingsMap(gzipFirst) }, "br, gzip");
+    expect(response.headers.get("content-encoding")).toBe("gzip");
+  });
+});
+
+describe("A5 serving", () => {
+  it("serves the file on disk, so Content-Length equals its size", async () => {
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await precompressDir(dir, ALL);
+    const variant = await stat(join(dir, "app.js.br"));
+    const response = await request({ dir, encodings: encodingsMap(ALL) }, "br");
+    expect(response.headers.get("content-encoding")).toBe("br");
+    // The discriminator: an on-the-fly encode is chunked and carries no length.
+    expect(response.headers.get("content-length")).toBe(String(variant.size));
+  });
+});
+
+describe("A6 rebuild reconciles variant content", () => {
+  it("a changed identity gets a variant of the new bytes", async () => {
+    const after = `${COMPRESSIBLE}export const added = ${JSON.stringify("x".repeat(500))};\n`;
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await precompressDir(dir, ALL);
+    await writeFile(join(dir, "app.js"), after);
+    await precompressDir(dir, ALL);
+    const decoded = brotliDecompressSync(await readFile(join(dir, "app.js.br"))).toString();
+    expect(decoded).toBe(after);
+  });
+});
+
+describe("F3 retire", () => {
+  it("m5 retires a variant this build did not emit", async () => {
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await precompressDir(dir, ALL);
+    expect(await exists(join(dir, "app.js.br"))).toBe(true);
+    // The same path stops being compressible: the old variant must not survive.
+    await writeFile(join(dir, "app.js"), incompressible(2048));
+    await precompressDir(dir, ALL);
+    expect(await exists(join(dir, "app.js.br"))).toBe(false);
+    expect(await exists(join(dir, "app.js.gz"))).toBe(false);
+  });
+
+  it("m7 leaves an orphan variant alone, because iteration is identity to variant", async () => {
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await writeFile(join(dir, "orphan.js.br"), "not ours");
+    await precompressDir(dir, ALL);
+    expect(await exists(join(dir, "orphan.js.br"))).toBe(true);
+  });
+
+  it("m6 leaves a suffix outside this build's encodings untouched", async () => {
+    const brOnly = resolvePrecompress({ encodings: ["br"] }) as ResolvedPrecompress;
+    const leftover = "from a build that had gzip on";
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await writeFile(join(dir, "app.js.gz"), leftover);
+    await precompressDir(dir, brOnly);
+    // Neither retired nor rewritten: srvx never probes a suffix outside the baked map.
+    expect(await readFile(join(dir, "app.js.gz"), "utf8")).toBe(leftover);
+  });
+
+  it("m8 never touches a publicDir pass-through variant", async () => {
+    const userOwned = "user supplied, deliberately not matching";
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await writeFile(join(dir, "app.js.br"), userOwned);
+    await precompressDir(dir, ALL, { passThrough: new Set(["app.js"]) });
+    expect(await readFile(join(dir, "app.js.br"), "utf8")).toBe(userOwned);
+  });
+
+  it("m9 throws when a variant cannot be removed", async () => {
+    await writeFile(join(dir, "app.js"), incompressible(2048));
+    // A directory where a variant would be retired: non-recursive rm rejects.
+    await mkdir(join(dir, "app.js.br"));
+    await writeFile(join(dir, "app.js.br", "blocker.txt"), "blocks rm");
+    await expect(precompressDir(dir, ALL)).rejects.toThrow(/could not remove/);
+  });
+});
+
+describe("PG-4 lookup is enabled only for the reconciled directory", () => {
+  const encodings: Record<string, string> = { br: ".br" };
+  const entryDir = resolve("/srv/app/dist/server");
+
+  it("A7 the same resolved directory retains lookup", () => {
+    const options = resolveStaticOptions({
+      entryDir,
+      bakedStatic: "../client",
+      runtimeStatic: undefined,
+      encodings,
+    });
+    expect(options).toEqual({ dir: resolve(entryDir, "../client"), encodings });
+  });
+
+  it("A7b the same directory spelled differently at runtime still retains lookup", () => {
+    const options = resolveStaticOptions({
+      entryDir,
+      bakedStatic: "../client",
+      runtimeStatic: "./../client",
+      encodings,
+    });
+    expect(options?.encodings).toEqual(encodings);
+  });
+
+  it("A8 a different runtime directory disables lookup", () => {
+    const options = resolveStaticOptions({
+      entryDir,
+      bakedStatic: "../client",
+      runtimeStatic: "../other",
+      encodings,
+    });
+    expect(options).toEqual({ dir: resolve(entryDir, "../other") });
+  });
+
+  it("A8b a disabled lookup serves the identity, not a planted stale variant", async () => {
+    const stale = `export const stale = ${JSON.stringify("STALE".repeat(400))};\n`;
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await writeFile(join(dir, "app.js.br"), Buffer.from(stale));
+    // The override tree was never walked, so `encodings` must not be passed.
+    const options = resolveStaticOptions({
+      entryDir,
+      bakedStatic: "../client",
+      runtimeStatic: dir,
+      encodings,
+    });
+    expect(options?.encodings).toBeUndefined();
+    const response = await request(options as ResolvedStaticOptions, "br");
+    const body = Buffer.from(await response.arrayBuffer());
+    const decoded =
+      response.headers.get("content-encoding") === "br" ? brotliDecompressSync(body).toString() : body.toString();
+    expect(decoded).toBe(COMPRESSIBLE);
+    expect(decoded).not.toContain("STALE");
+  });
+
+  it("A9 no baked directory means no reconciled tree, so no lookup", () => {
+    const options = resolveStaticOptions({
+      entryDir,
+      bakedStatic: false,
+      runtimeStatic: "../client",
+      encodings,
+    });
+    expect(options).toEqual({ dir: resolve(entryDir, "../client") });
+  });
+
+  it("a non-string effective value yields no static middleware at all", () => {
+    for (const runtimeStatic of [false, true, undefined] as const) {
+      expect(resolveStaticOptions({ entryDir, bakedStatic: false, runtimeStatic, encodings })).toBeUndefined();
+    }
+  });
+
+  it("a gzip variant decodes to the identity bytes", async () => {
+    const gzipOnly = resolvePrecompress({ encodings: ["gzip"] }) as ResolvedPrecompress;
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await precompressDir(dir, gzipOnly);
+    const response = await request({ dir, encodings: encodingsMap(gzipOnly) }, "gzip");
+    expect(gunzipSync(Buffer.from(await response.arrayBuffer())).toString()).toBe(COMPRESSIBLE);
+  });
+});
+
+describe("off is inert", () => {
+  it("resolvePrecompress returns undefined for every off value", () => {
+    for (const off of [undefined, false] as const) expect(resolvePrecompress(off)).toBeUndefined();
+  });
+
+  it("encodings default to br then gzip", () => {
+    expect(resolvePrecompress(true)?.encodings).toEqual(["br", "gzip"]);
+    expect(encodingsMap(resolvePrecompress(true) as ResolvedPrecompress)).toEqual({ br: ".br", gzip: ".gz" });
   });
 });

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -11,94 +11,26 @@ import { type ResolvedStaticOptions, resolveStaticOptions } from "./static-optio
 import { resolveStaticDir, resolveStaticHint } from "./vite.js";
 
 /**
- * Vite 8 leaves `build.outDir` **relative to `config.root`** — in `configResolved`,
- * per-environment, and in `getTopLevelConfig().environments`. This stub models that
- * shape; `vite.spec.ts`'s older stub passes absolute outDirs, which Vite never produces.
+ * Vite 8 leaves `build.outDir` relative to `config.root`, so a resolver that anchors
+ * either operand to `process.cwd()` addresses a different tree whenever the build runs
+ * from elsewhere (`vite build --root <subdir>`). The incumbent `vite.spec.ts` covers the
+ * layout matrix at the hint interface, but only with absolute outDirs, where the anchor
+ * is the identity and this regression is invisible.
  */
-function makeEnv(opts: { root: string; serverOutDir: string; clientOutDir?: string }): Environment {
-  const envs: Record<string, { consumer: string; build: { outDir: string } }> = {
-    ssr: { consumer: "server", build: { outDir: opts.serverOutDir } },
-  };
-  if (opts.clientOutDir !== undefined) {
-    envs.client = { consumer: "client", build: { outDir: opts.clientOutDir } };
-  }
-  return {
-    config: { root: opts.root, build: { outDir: opts.serverOutDir } },
-    getTopLevelConfig: () => ({ environments: envs }),
+it("walker and server address one directory when config.root is not the cwd", () => {
+  const root = resolve(process.cwd(), "..", "ud-fixture-root");
+  const env = {
+    config: { root, build: { outDir: "dist/server" } },
+    getTopLevelConfig: () => ({ environments: {} }),
   } as unknown as Environment;
-}
 
-/**
- * A root that is deliberately NOT `process.cwd()`. Anything anchored to the cwd instead
- * of to `config.root` resolves somewhere else entirely from here.
- */
-const ROOT = resolve(process.cwd(), "..", "ud-fixture-root");
+  const walked = resolveStaticDir(env, "dist/client");
+  const hint = resolveStaticHint(env, "dist/client");
 
-describe("resolveStaticDir", () => {
-  it("anchors a relative client outDir to config.root, not to process.cwd()", () => {
-    const env = makeEnv({ root: ROOT, serverOutDir: "dist/server", clientOutDir: "dist/client" });
-    expect(resolveStaticDir(env, undefined)).toBe(resolve(ROOT, "dist/client"));
-  });
-
-  it("anchors a relative configured path to config.root", () => {
-    const env = makeEnv({ root: ROOT, serverOutDir: "dist/server" });
-    expect(resolveStaticDir(env, "public-assets")).toBe(resolve(ROOT, "public-assets"));
-  });
-
-  it("returns undefined when static serving is off", () => {
-    const env = makeEnv({ root: ROOT, serverOutDir: "dist/server", clientOutDir: "dist/client" });
-    expect(resolveStaticDir(env, false)).toBeUndefined();
-  });
-
-  it("returns undefined when no client environment exists and nothing is configured", () => {
-    const env = makeEnv({ root: ROOT, serverOutDir: "dist/server" });
-    expect(resolveStaticDir(env, undefined)).toBeUndefined();
-  });
-});
-
-describe("resolveStaticHint with a relative outDir", () => {
-  it("is independent of process.cwd() for a configured path", () => {
-    const env = makeEnv({ root: ROOT, serverOutDir: "dist/server" });
-    expect(resolveStaticHint(env, "dist/client")).toBe("../client");
-  });
-
-  it("is independent of process.cwd() for an auto-detected client outDir", () => {
-    const env = makeEnv({ root: ROOT, serverOutDir: "dist/server", clientOutDir: "dist/client" });
-    expect(resolveStaticHint(env, undefined)).toBe("../client");
-  });
-});
-
-/**
- * The property U2 exists for: the directory precompression walks and the directory the
- * built server resolves at runtime are the same path. `serve.ts` computes the latter as
- * `resolve(<dir of the server entry>, hint)`, which is the server outDir at runtime.
- */
-describe("walker and server agree on one directory", () => {
-  const cases: Array<[string, string | boolean | undefined, string, string?]> = [
-    ["auto-detected sibling", undefined, "dist/server", "dist/client"],
-    ["configured relative path", "dist/client", "dist/server", "dist/client"],
-    ["configured path outside the build tree", "../shared/static", "dist/server", "dist/client"],
-    ["nested server outDir", undefined, "dist/nested/server", "dist/nested/client"],
-    ["same directory for both", undefined, "dist", "dist"],
-  ];
-
-  for (const [name, configured, serverOutDir, clientOutDir] of cases) {
-    it(name, () => {
-      const env = makeEnv({ root: ROOT, serverOutDir, clientOutDir });
-      const walked = resolveStaticDir(env, configured);
-      const hint = resolveStaticHint(env, configured);
-      expect(hint).not.toBe(false);
-      const servedAtRuntime = resolve(resolve(ROOT, serverOutDir), hint as string);
-      expect(servedAtRuntime).toBe(walked);
-    });
-  }
-
-  it("holds for an absolute configured path, from any runtime location", () => {
-    const abs = resolve(ROOT, "var", "www", "static");
-    const env = makeEnv({ root: ROOT, serverOutDir: "dist/server" });
-    const hint = resolveStaticHint(env, abs);
-    expect(resolve("/somewhere/else/entirely", hint as string)).toBe(resolveStaticDir(env, abs));
-  });
+  expect(walked).toBe(resolve(root, "dist/client"));
+  expect(hint).toBe("../client");
+  // `serve.ts` resolves the hint against the server entry's directory at runtime.
+  expect(resolve(resolve(root, "dist/server"), hint as string)).toBe(walked);
 });
 
 // ── emission, serving, and the F3 retire mechanism ──────────────────────────────

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { brotliDecompressSync, gunzipSync } from "node:zlib";
@@ -175,6 +175,22 @@ describe("repeat passes over one directory", () => {
     const second = await precompressDir(dir, ALL);
     expect(second.written).toBe(2);
     expect(await exists(join(dir, "page.html.br"))).toBe(true);
+  });
+
+  it("reconciles a changed identity whose mtime was preserved below its variant's", async () => {
+    const changed = `${COMPRESSIBLE}export const changed = true;\n`;
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await precompressDir(dir, ALL);
+    await writeFile(join(dir, "app.js"), changed);
+    // A cache restore, an archive extraction or a timestamp-preserving copy leaves the
+    // identity older than the variant made from its previous contents. Metadata says
+    // "current"; the bytes say otherwise, and the bytes decide.
+    const variant = await stat(join(dir, "app.js.br"));
+    const backdated = new Date(variant.mtimeMs - 5000);
+    await utimes(join(dir, "app.js"), backdated, backdated);
+    await precompressDir(dir, ALL);
+    expect(brotliDecompressSync(await readFile(join(dir, "app.js.br"))).toString()).toBe(changed);
+    expect(gunzipSync(await readFile(join(dir, "app.js.gz"))).toString()).toBe(changed);
   });
 
   it("the reported count matches the variants actually written", async () => {

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -6,13 +6,7 @@ import { brotliCompressSync, brotliDecompressSync, gunzipSync } from "node:zlib"
 import { staticMiddleware } from "srvx/static";
 import type { Environment } from "vite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  encodingsMap,
-  type PrecompressEncoding,
-  precompressDir,
-  type ResolvedPrecompress,
-  resolvePrecompress,
-} from "./precompress.js";
+import { encodingsMap, precompressDir, type ResolvedPrecompress, resolvePrecompress } from "./precompress.js";
 import { type ResolvedStaticOptions, resolveStaticOptions } from "./static-options.js";
 import { node, resolveStaticDir, resolveStaticHint } from "./vite.js";
 
@@ -384,16 +378,6 @@ describe("the emission pass sees everything the build wrote", () => {
     expect(plugin().applyToEnvironment).toBeUndefined();
   });
 });
-
-/**
- * `PrecompressEncoding` derives from the codec table's keys, so a key added there widens it
- * silently: `encodingsMap` would hand srvx an encoding it never negotiates, and the variants
- * would be written and never served. Checked bidirectionally — assignability alone passes a
- * widened union. This one fails under `test:types`, not `vitest`.
- */
-type Eq<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
-const encodingsAreExactly: Eq<PrecompressEncoding, "br" | "gzip"> = true;
-void encodingsAreExactly;
 
 describe("off is inert", () => {
   it("resolvePrecompress returns undefined for every off value", () => {

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -8,7 +8,7 @@ import type { Environment } from "vite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { encodingsMap, precompressDir, type ResolvedPrecompress, resolvePrecompress } from "./precompress.js";
 import { type ResolvedStaticOptions, resolveStaticOptions } from "./static-options.js";
-import { resolveStaticDir, resolveStaticHint } from "./vite.js";
+import { node, resolveStaticDir, resolveStaticHint } from "./vite.js";
 
 /**
  * Vite 8 leaves `build.outDir` relative to `config.root`, so a resolver that anchors
@@ -324,6 +324,52 @@ describe("lookup is enabled only for the reconciled directory", () => {
     for (const runtimeStatic of [false, true, undefined] as const) {
       expect(resolveStaticOptions({ entryDir, bakedStatic: false, runtimeStatic, encodings })).toBeUndefined();
     }
+  });
+});
+
+describe("the emission pass sees everything the build wrote", () => {
+  interface PrecompressPlugin {
+    applyToEnvironment?: unknown;
+    closeBundle: { order?: string; handler: (this: unknown) => Promise<void> };
+  }
+
+  function plugin(): PrecompressPlugin {
+    const found = node({ precompress: true }).find((p) => p.name === "ud:node:precompress");
+    if (!found) throw new Error("no ud:node:precompress plugin");
+    return found as unknown as PrecompressPlugin;
+  }
+
+  /** What Vite binds as `this` for one environment's `closeBundle` — only the parts the
+   *  handler reads. `served` is both the root and the client environment's outDir, so the
+   *  resolver lands on it. */
+  function dispatch(served: string) {
+    return {
+      environment: {
+        name: "ssr",
+        config: { root: served, publicDir: false, build: { outDir: ".", copyPublicDir: false } },
+        getTopLevelConfig: () => ({ environments: { client: { consumer: "client", build: { outDir: "." } } } }),
+        logger: { info: () => {} },
+      },
+    };
+  }
+
+  it("runs after the default-order closeBundle hooks, so their files are in the walk", () => {
+    // Hook-local, and this plugin owns one hook — `enforce` would scope the same property
+    // plugin-wide, which is broader than the property needs.
+    expect(plugin().closeBundle.order).toBe("post");
+  });
+
+  it("precompresses the served directory during the pass that is not the client's", async () => {
+    await writeFile(join(dir, "prerendered.html"), COMPRESSIBLE);
+    await plugin().closeBundle.handler.call(dispatch(dir));
+    // vike writes pre-rendered HTML from the ssr environment. Nothing else walks after it.
+    expect(await exists(join(dir, "prerendered.html.br"))).toBe(true);
+  });
+
+  it("declares no applyToEnvironment, so Vite dispatches it to all of them", () => {
+    // Vite's only per-plugin environment filter. The assertion above cannot see it:
+    // calling a handler directly bypasses the dispatch that consults it.
+    expect(plugin().applyToEnvironment).toBeUndefined();
   });
 });
 

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -203,7 +203,23 @@ describe("repeat passes over one directory", () => {
     expect(await exists(join(dir, "app.js.gz"))).toBe(false);
   });
 
-  it("replaces a correspondent variant that is not smaller than its identity", async () => {
+  it("keeps and serves a variant exactly the same size as its identity", async () => {
+    const brOnly = resolvePrecompress({ threshold: 0, encodings: ["br"] }) as ResolvedPrecompress;
+    // Witness for the boundary: brotli q11 encodes 10 repeated bytes to exactly 10 bytes.
+    // The hazard is a *larger* variant; an equal one costs the same on the wire and still
+    // spares the server an on-the-fly encode, so it is kept.
+    await writeFile(join(dir, "app.js"), "a".repeat(10));
+    const { written } = await precompressDir(dir, brOnly);
+    const identity = await stat(join(dir, "app.js"));
+    const variant = await stat(join(dir, "app.js.br"));
+    expect(variant.size).toBe(identity.size);
+    expect(written).toBe(1);
+    const response = await request({ dir, encodings: encodingsMap(brOnly) }, "br");
+    expect(response.headers.get("content-encoding")).toBe("br");
+    expect(response.headers.get("content-length")).toBe(String(variant.size));
+  });
+
+  it("replaces a correspondent variant that is larger than its identity", async () => {
     const brOnly = resolvePrecompress({ threshold: 0, encodings: ["br"] }) as ResolvedPrecompress;
     await writeFile(join(dir, "tiny.js"), "x");
     // Valid brotli that decodes to the identity, yet larger than it. srvx compares nothing,

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -6,7 +6,13 @@ import { brotliCompressSync, brotliDecompressSync, gunzipSync } from "node:zlib"
 import { staticMiddleware } from "srvx/static";
 import type { Environment } from "vite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { encodingsMap, precompressDir, type ResolvedPrecompress, resolvePrecompress } from "./precompress.js";
+import {
+  encodingsMap,
+  type PrecompressEncoding,
+  precompressDir,
+  type ResolvedPrecompress,
+  resolvePrecompress,
+} from "./precompress.js";
 import { type ResolvedStaticOptions, resolveStaticOptions } from "./static-options.js";
 import { node, resolveStaticDir, resolveStaticHint } from "./vite.js";
 
@@ -378,6 +384,16 @@ describe("the emission pass sees everything the build wrote", () => {
     expect(plugin().applyToEnvironment).toBeUndefined();
   });
 });
+
+/**
+ * `PrecompressEncoding` derives from the codec table's keys, so a key added there widens it
+ * silently: `encodingsMap` would hand srvx an encoding it never negotiates, and the variants
+ * would be written and never served. Checked bidirectionally — assignability alone passes a
+ * widened union. This one fails under `test:types`, not `vitest`.
+ */
+type Eq<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+const encodingsAreExactly: Eq<PrecompressEncoding, "br" | "gzip"> = true;
+void encodingsAreExactly;
 
 describe("off is inert", () => {
   it("resolvePrecompress returns undefined for every off value", () => {

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { brotliDecompressSync, gunzipSync } from "node:zlib";
@@ -152,6 +152,38 @@ describe("A6 rebuild reconciles variant content", () => {
     await precompressDir(dir, ALL);
     const decoded = brotliDecompressSync(await readFile(join(dir, "app.js.br"))).toString();
     expect(decoded).toBe(after);
+  });
+});
+
+describe("repeat passes over one directory", () => {
+  it("a second pass does no work — emission runs once per environment", async () => {
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    const first = await precompressDir(dir, ALL);
+    const before = (await stat(join(dir, "app.js.br"))).mtimeMs;
+    const second = await precompressDir(dir, ALL);
+    expect(first.written).toBe(2);
+    expect(second.written).toBe(0);
+    // Not merely "reported nothing": the file was not rewritten either.
+    expect((await stat(join(dir, "app.js.br"))).mtimeMs).toBe(before);
+  });
+
+  it("a file written between passes is still covered", async () => {
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await precompressDir(dir, ALL);
+    // What a framework's pre-render does: more servable files appear after the first pass.
+    await writeFile(join(dir, "page.html"), COMPRESSIBLE);
+    const second = await precompressDir(dir, ALL);
+    expect(second.written).toBe(2);
+    expect(await exists(join(dir, "page.html.br"))).toBe(true);
+  });
+
+  it("the reported count matches the variants actually written", async () => {
+    for (let i = 0; i < 10; i++) {
+      await writeFile(join(dir, `f${i}.js`), `${COMPRESSIBLE}// ${i}\n`);
+    }
+    const { written } = await precompressDir(dir, ALL);
+    const names = await readdir(dir);
+    expect(written).toBe(names.filter((n) => n.endsWith(".br") || n.endsWith(".gz")).length);
   });
 });
 

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -78,6 +78,13 @@ const exists = async (path: string) => {
   }
 };
 
+/** A second instance of the module under test: the query makes the loader treat it as a distinct
+ *  specifier, which is what a second copy on disk is. */
+function loadSecondCopy(): Promise<typeof import("./precompress.js")> {
+  const distinctSpecifier = "./precompress.js?copy=2";
+  return import(distinctSpecifier);
+}
+
 async function request(options: ResolvedStaticOptions, encoding: string) {
   const middleware = staticMiddleware(options);
   return middleware(
@@ -183,6 +190,16 @@ describe("repeat passes over one directory", () => {
     expect(second.written).toBe(2);
     expect(await exists(join(dir, "app.js.br"))).toBe(true);
     expect(await exists(join(dir, "app.js.gz"))).toBe(true);
+  });
+
+  it("a second copy of this module shares the memo", async () => {
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    expect((await precompressDir(dir, ALL)).written).toBe(2);
+
+    // What dual resolution or two installed versions produce: another instance of this module,
+    // with its own module scope. A memo living there re-encodes what this pass just wrote.
+    const copy = await loadSecondCopy();
+    expect((await copy.precompressDir(dir, ALL)).written).toBe(0);
   });
 
   it("a file written between passes is still covered", async () => {

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -148,6 +148,29 @@ describe("repeat passes over one directory", () => {
     expect((await stat(join(dir, "app.js.br"))).mtimeMs).toBe(backdated);
   });
 
+  it("a later pass over unchanged bytes never reads the variants", async () => {
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await precompressDir(dir, ALL);
+    // Corrupt the variant. Decoding it would fail and force a rewrite, so its survival is
+    // what proves the second pass skipped on the memo instead of reading anything.
+    await writeFile(join(dir, "app.js.br"), Buffer.from("not brotli"));
+    const second = await precompressDir(dir, ALL);
+    expect(second.written).toBe(0);
+    expect((await readFile(join(dir, "app.js.br"))).toString()).toBe("not brotli");
+  });
+
+  it("re-emits when the variants were deleted after the pass that wrote them", async () => {
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await precompressDir(dir, ALL);
+    // A cleaned output directory, or a second build in the same process: the memo still
+    // holds these bytes, so only checking the variants are there catches it.
+    await rm(join(dir, "app.js.br"));
+    await rm(join(dir, "app.js.gz"));
+    const second = await precompressDir(dir, ALL);
+    expect(second.written).toBe(2);
+    expect(await exists(join(dir, "app.js.br"))).toBe(true);
+  });
+
   it("a file written between passes is still covered", async () => {
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
     await precompressDir(dir, ALL);

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -170,7 +170,7 @@ describe("repeat passes over one directory", () => {
     const first = await precompressDir(dir, ALL);
     expect(first.written).toBe(2);
 
-    // A second `vite.build()` in one process, where the output directory was emptied and
+    // Models a second `vite.build()` in one process, where the output directory was emptied and
     // byte-identical sources rebuilt. The record describes files that are now gone, so without
     // the reset the digests still match and the whole tree is skipped — nothing is emitted.
     await rm(dir, { recursive: true, force: true });
@@ -416,7 +416,7 @@ describe("the emission pass sees everything the build wrote", () => {
     await p.closeBundle.handler.call(dispatch(dir));
     expect(await exists(join(dir, "app.js.br"))).toBe(true);
 
-    // A second `vite.build()` that emptied the output directory and rebuilt identical sources.
+    // Models a second `vite.build()` that emptied the output directory and rebuilt identical sources.
     // The reset has to come from the plugin's own `configResolved` — this test never calls
     // `forgetReconciled`, so a record surviving the build boundary skips the whole tree.
     await rm(dir, { recursive: true, force: true });

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -159,6 +159,48 @@ describe("repeat passes over one directory", () => {
     expect((await readFile(join(dir, "app.js.br"))).toString()).toBe("not brotli");
   });
 
+  it("a later pass re-encodes nothing for bytes that earned no variant", async () => {
+    await writeFile(join(dir, "blob.wasm"), incompressible(2048));
+    const first = await precompressDir(dir, ALL);
+    expect(first.written).toBe(0);
+    // Nothing on disk to check, so only the memo can make this a skip. Planting variants the
+    // pass did not write proves it: a second pass leaves them exactly as found.
+    await writeFile(join(dir, "blob.wasm.br"), Buffer.from("planted"));
+    const second = await precompressDir(dir, ALL);
+    expect(second.written).toBe(0);
+    expect((await readFile(join(dir, "blob.wasm.br"))).toString()).toBe("planted");
+  });
+
+  it("skips on the variants a file actually earned, not the ones configured", async () => {
+    // brotli keeps this (its static dictionary catches the prefix); gzip comes out larger and
+    // is retired. The memo must then check `.br` alone — checking `.gz` too would find it
+    // missing and re-encode both on every later pass.
+    const partial = Buffer.concat([
+      Buffer.from('<!DOCTYPE html><html><head><meta charset="utf-8"><title>'),
+      incompressible(1024),
+    ]);
+    await writeFile(join(dir, "page.html"), partial);
+    await precompressDir(dir, ALL);
+    expect(await exists(join(dir, "page.html.br"))).toBe(true);
+    expect(await exists(join(dir, "page.html.gz"))).toBe(false);
+
+    await writeFile(join(dir, "page.html.br"), Buffer.from("planted"));
+    const second = await precompressDir(dir, ALL);
+    expect(second.written).toBe(0);
+    expect((await readFile(join(dir, "page.html.br"))).toString()).toBe("planted");
+  });
+
+  it("a pass configured with more encodings does not hit an earlier pass's memo", async () => {
+    const brOnly = resolvePrecompress({ encodings: ["br"] }) as ResolvedPrecompress;
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await precompressDir(dir, brOnly);
+    expect(await exists(join(dir, "app.js.gz"))).toBe(false);
+    // Same bytes, so the digest matches; only the recorded configuration separates them.
+    const second = await precompressDir(dir, ALL);
+    expect(second.written).toBe(2);
+    expect(await exists(join(dir, "app.js.gz"))).toBe(true);
+  });
+
   it("re-emits when the variants were deleted after the pass that wrote them", async () => {
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
     await precompressDir(dir, ALL);

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -171,8 +171,9 @@ describe("repeat passes over one directory", () => {
     expect(first.written).toBe(2);
 
     // Models a second `vite.build()` in one process, where the output directory was emptied and
-    // byte-identical sources rebuilt. The record describes files that are now gone, so without
-    // the reset the digests still match and the whole tree is skipped — nothing is emitted.
+    // byte-identical sources rebuilt. The sources are back and their digests still match, while
+    // the variants beside them are gone — so without the reset the whole tree is skipped and
+    // nothing is emitted.
     await rm(dir, { recursive: true, force: true });
     await mkdir(dir, { recursive: true });
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -33,14 +33,8 @@ it("walker and server address one directory when config.root is not the cwd", ()
   expect(resolve(resolve(root, "dist/server"), hint as string)).toBe(walked);
 });
 
-// ── emission, serving, and the F3 retire mechanism ──────────────────────────────
-
-/**
- * Deterministic bytes that neither encoder can shrink — a SHA-256 chain, so no
- * `Math.random` and no fixture file. Measured: brotli q11 and gzip 9 both come out
- * larger than the input. (A linear generator is not enough; its output still
- * compresses by roughly a third.)
- */
+/** Deterministic bytes that neither brotli nor gzip can shrink. A linear generator is
+ *  not enough — its output still compresses by roughly a third. */
 function incompressible(length: number): Buffer {
   const chunks: Buffer[] = [];
   let total = 0;
@@ -81,7 +75,7 @@ async function request(options: ResolvedStaticOptions, encoding: string) {
 }
 
 describe("precompress emission", () => {
-  it("A1 emits a variant smaller than its identity (emission only, not proof of serving)", async () => {
+  it("emits a variant smaller than its identity", async () => {
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
     await precompressDir(dir, ALL);
     const identity = await stat(join(dir, "app.js"));
@@ -89,29 +83,14 @@ describe("precompress emission", () => {
     expect(variant.size).toBeLessThan(identity.size);
   });
 
-  it("A2 skips an extension srvx never negotiates", async () => {
+  it("skips an extension srvx never negotiates", async () => {
     await writeFile(join(dir, "app.js.map"), COMPRESSIBLE);
     await precompressDir(dir, ALL);
     expect(await exists(join(dir, "app.js.map.br"))).toBe(false);
   });
-
-  it("A3 skips an eligible, above-threshold file whose encoding is not smaller", async () => {
-    const noise = incompressible(2048);
-    await writeFile(join(dir, "noise.txt"), noise);
-    expect(noise.byteLength).toBeGreaterThan(ALL.threshold);
-    await precompressDir(dir, ALL);
-    expect(await exists(join(dir, "noise.txt.br"))).toBe(false);
-    expect(await exists(join(dir, "noise.txt.gz"))).toBe(false);
-  });
-
-  it("A3b skips a file under the threshold", async () => {
-    await writeFile(join(dir, "tiny.js"), "export const a = 1;\n");
-    await precompressDir(dir, ALL);
-    expect(await exists(join(dir, "tiny.js.br"))).toBe(false);
-  });
 });
 
-describe("A4 encodings order and selection", () => {
+describe("encodings order and selection", () => {
   it("emits only the configured encoding and bakes only its suffix", async () => {
     const gzipOnly = resolvePrecompress({ encodings: ["gzip"] }) as ResolvedPrecompress;
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
@@ -131,7 +110,7 @@ describe("A4 encodings order and selection", () => {
   });
 });
 
-describe("A5 serving", () => {
+describe("serving", () => {
   it("serves the file on disk, so Content-Length equals its size", async () => {
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
     await precompressDir(dir, ALL);
@@ -140,18 +119,6 @@ describe("A5 serving", () => {
     expect(response.headers.get("content-encoding")).toBe("br");
     // The discriminator: an on-the-fly encode is chunked and carries no length.
     expect(response.headers.get("content-length")).toBe(String(variant.size));
-  });
-});
-
-describe("A6 rebuild reconciles variant content", () => {
-  it("a changed identity gets a variant of the new bytes", async () => {
-    const after = `${COMPRESSIBLE}export const added = ${JSON.stringify("x".repeat(500))};\n`;
-    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
-    await precompressDir(dir, ALL);
-    await writeFile(join(dir, "app.js"), after);
-    await precompressDir(dir, ALL);
-    const decoded = brotliDecompressSync(await readFile(join(dir, "app.js.br"))).toString();
-    expect(decoded).toBe(after);
   });
 });
 
@@ -203,20 +170,15 @@ describe("repeat passes over one directory", () => {
     expect(await exists(join(dir, "app.js.gz"))).toBe(false);
   });
 
-  it("keeps and serves a variant exactly the same size as its identity", async () => {
+  it("keeps a variant exactly the same size as its identity", async () => {
     const brOnly = resolvePrecompress({ threshold: 0, encodings: ["br"] }) as ResolvedPrecompress;
-    // Witness for the boundary: brotli q11 encodes 10 repeated bytes to exactly 10 bytes.
-    // The hazard is a *larger* variant; an equal one costs the same on the wire and still
-    // spares the server an on-the-fly encode, so it is kept.
+    // Boundary witness: brotli q11 encodes 10 repeated bytes to exactly 10 bytes. The
+    // hazard is a *larger* variant; an equal one costs the same on the wire and still
+    // spares the server an on-the-fly encode.
     await writeFile(join(dir, "app.js"), "a".repeat(10));
     const { written } = await precompressDir(dir, brOnly);
-    const identity = await stat(join(dir, "app.js"));
-    const variant = await stat(join(dir, "app.js.br"));
-    expect(variant.size).toBe(identity.size);
+    expect((await stat(join(dir, "app.js.br"))).size).toBe((await stat(join(dir, "app.js"))).size);
     expect(written).toBe(1);
-    const response = await request({ dir, encodings: encodingsMap(brOnly) }, "br");
-    expect(response.headers.get("content-encoding")).toBe("br");
-    expect(response.headers.get("content-length")).toBe(String(variant.size));
   });
 
   it("replaces a correspondent variant that is larger than its identity", async () => {
@@ -248,8 +210,8 @@ describe("repeat passes over one directory", () => {
   });
 });
 
-describe("F3 retire", () => {
-  it("m5 retires a variant this build did not emit", async () => {
+describe("retiring variants this build did not write", () => {
+  it("retires a variant this build did not emit", async () => {
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
     await precompressDir(dir, ALL);
     expect(await exists(join(dir, "app.js.br"))).toBe(true);
@@ -260,14 +222,14 @@ describe("F3 retire", () => {
     expect(await exists(join(dir, "app.js.gz"))).toBe(false);
   });
 
-  it("m7 leaves an orphan variant alone, because iteration is identity to variant", async () => {
+  it("leaves an orphan variant alone: iteration goes identity to variant", async () => {
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
     await writeFile(join(dir, "orphan.js.br"), "not ours");
     await precompressDir(dir, ALL);
     expect(await exists(join(dir, "orphan.js.br"))).toBe(true);
   });
 
-  it("m6 leaves a suffix outside this build's encodings untouched", async () => {
+  it("leaves a suffix outside this build's encodings untouched", async () => {
     const brOnly = resolvePrecompress({ encodings: ["br"] }) as ResolvedPrecompress;
     const leftover = "from a build that had gzip on";
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
@@ -277,7 +239,7 @@ describe("F3 retire", () => {
     expect(await readFile(join(dir, "app.js.gz"), "utf8")).toBe(leftover);
   });
 
-  it("m8 never touches a publicDir pass-through variant", async () => {
+  it("never touches a publicDir pass-through variant", async () => {
     const userOwned = "user supplied, deliberately not matching";
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
     await writeFile(join(dir, "app.js.br"), userOwned);
@@ -285,7 +247,7 @@ describe("F3 retire", () => {
     expect(await readFile(join(dir, "app.js.br"), "utf8")).toBe(userOwned);
   });
 
-  it("m9 throws when a variant cannot be removed", async () => {
+  it("fails the build when a variant cannot be removed", async () => {
     await writeFile(join(dir, "app.js"), incompressible(2048));
     // A directory where a variant would be retired: non-recursive rm rejects.
     await mkdir(join(dir, "app.js.br"));
@@ -296,11 +258,11 @@ describe("F3 retire", () => {
   });
 });
 
-describe("PG-4 lookup is enabled only for the reconciled directory", () => {
+describe("lookup is enabled only for the reconciled directory", () => {
   const encodings: Record<string, string> = { br: ".br" };
   const entryDir = resolve("/srv/app/dist/server");
 
-  it("A7 the same resolved directory retains lookup", () => {
+  it("the same resolved directory retains lookup", () => {
     const options = resolveStaticOptions({
       entryDir,
       bakedStatic: "../client",
@@ -310,7 +272,7 @@ describe("PG-4 lookup is enabled only for the reconciled directory", () => {
     expect(options).toEqual({ dir: resolve(entryDir, "../client"), encodings });
   });
 
-  it("A7b the same directory spelled differently at runtime still retains lookup", () => {
+  it("the same directory spelled differently at runtime still retains lookup", () => {
     const options = resolveStaticOptions({
       entryDir,
       bakedStatic: "../client",
@@ -320,17 +282,7 @@ describe("PG-4 lookup is enabled only for the reconciled directory", () => {
     expect(options?.encodings).toEqual(encodings);
   });
 
-  it("A8 a different runtime directory disables lookup", () => {
-    const options = resolveStaticOptions({
-      entryDir,
-      bakedStatic: "../client",
-      runtimeStatic: "../other",
-      encodings,
-    });
-    expect(options).toEqual({ dir: resolve(entryDir, "../other") });
-  });
-
-  it("A8b a disabled lookup serves the identity, not a planted stale variant", async () => {
+  it("a disabled lookup serves the identity, not a planted stale variant", async () => {
     const stale = `export const stale = ${JSON.stringify("STALE".repeat(400))};\n`;
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
     await writeFile(join(dir, "app.js.br"), Buffer.from(stale));
@@ -350,7 +302,7 @@ describe("PG-4 lookup is enabled only for the reconciled directory", () => {
     expect(decoded).not.toContain("STALE");
   });
 
-  it("A9 no baked directory means no reconciled tree, so no lookup", () => {
+  it("no baked directory means no reconciled tree, so no lookup", () => {
     const options = resolveStaticOptions({
       entryDir,
       bakedStatic: false,
@@ -364,14 +316,6 @@ describe("PG-4 lookup is enabled only for the reconciled directory", () => {
     for (const runtimeStatic of [false, true, undefined] as const) {
       expect(resolveStaticOptions({ entryDir, bakedStatic: false, runtimeStatic, encodings })).toBeUndefined();
     }
-  });
-
-  it("a gzip variant decodes to the identity bytes", async () => {
-    const gzipOnly = resolvePrecompress({ encodings: ["gzip"] }) as ResolvedPrecompress;
-    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
-    await precompressDir(dir, gzipOnly);
-    const response = await request({ dir, encodings: encodingsMap(gzipOnly) }, "gzip");
-    expect(gunzipSync(Buffer.from(await response.arrayBuffer())).toString()).toBe(COMPRESSIBLE);
   });
 });
 

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -6,7 +6,13 @@ import { brotliCompressSync, brotliDecompressSync, gunzipSync } from "node:zlib"
 import { staticMiddleware } from "srvx/static";
 import type { Environment } from "vite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { encodingsMap, precompressDir, type ResolvedPrecompress, resolvePrecompress } from "./precompress.js";
+import {
+  encodingsMap,
+  forgetReconciled,
+  precompressDir,
+  type ResolvedPrecompress,
+  resolvePrecompress,
+} from "./precompress.js";
 import { type ResolvedStaticOptions, resolveStaticOptions } from "./static-options.js";
 import { node, resolveStaticDir, resolveStaticHint } from "./vite.js";
 
@@ -165,11 +171,12 @@ describe("repeat passes over one directory", () => {
     expect(first.written).toBe(2);
 
     // What a second `vite.build()` in one process does: empty the output directory, then rebuild
-    // byte-identical sources. The memo still holds those bytes, so a record that does not check
-    // its variants are on disk skips the whole tree and the build emits nothing at all.
+    // byte-identical sources. The record describes files that are now gone, so without the reset
+    // the digests still match and the whole tree is skipped — the build emits nothing at all.
     await rm(dir, { recursive: true, force: true });
     await mkdir(dir, { recursive: true });
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    forgetReconciled();
 
     const second = await precompressDir(dir, ALL);
     expect(second.written).toBe(2);
@@ -206,8 +213,9 @@ describe("repeat passes over one directory", () => {
   it("retires variants that no longer meet a raised threshold", async () => {
     await writeFile(join(dir, "app.js"), "x".repeat(4096));
     await precompressDir(dir, resolvePrecompress({ threshold: 0 }) as ResolvedPrecompress);
-    // The variants still decode to the identity, so byte correspondence alone would keep
-    // them — but this build's policy no longer wants them at all.
+    // The source is unchanged, so the record still matches it — but eligibility is decided
+    // before the record is consulted, and this build's policy no longer wants them at all.
+    // This is the only control on that ordering: invert it and every other test still passes.
     await precompressDir(dir, resolvePrecompress({ threshold: 8192 }) as ResolvedPrecompress);
     expect(await exists(join(dir, "app.js.br"))).toBe(false);
     expect(await exists(join(dir, "app.js.gz"))).toBe(false);
@@ -365,6 +373,7 @@ describe("lookup is enabled only for the reconciled directory", () => {
 describe("the emission pass sees everything the build wrote", () => {
   interface PrecompressPlugin {
     applyToEnvironment?: unknown;
+    configResolved: () => void;
     closeBundle: { order?: string; handler: (this: unknown) => Promise<void> };
   }
 
@@ -399,6 +408,25 @@ describe("the emission pass sees everything the build wrote", () => {
     await plugin().closeBundle.handler.call(dispatch(dir));
     // vike writes pre-rendered HTML from the ssr environment. Nothing else walks after it.
     expect(await exists(join(dir, "prerendered.html.br"))).toBe(true);
+  });
+
+  it("a second build through the plugin emits again, with no reset from the test", async () => {
+    const p = plugin();
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+    await p.closeBundle.handler.call(dispatch(dir));
+    expect(await exists(join(dir, "app.js.br"))).toBe(true);
+
+    // A second `vite.build()`: the output directory is emptied and identical sources rebuilt.
+    // The reset has to come from the plugin's own `configResolved` — this test never calls
+    // `forgetReconciled`, so a record surviving the build boundary skips the whole tree.
+    await rm(dir, { recursive: true, force: true });
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "app.js"), COMPRESSIBLE);
+
+    p.configResolved();
+    await p.closeBundle.handler.call(dispatch(dir));
+    expect(await exists(join(dir, "app.js.br"))).toBe(true);
+    expect(await exists(join(dir, "app.js.gz"))).toBe(true);
   });
 
   it("declares no applyToEnvironment, so Vite dispatches it to all of them", () => {

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { brotliDecompressSync, gunzipSync } from "node:zlib";
+import { brotliCompressSync, brotliDecompressSync, gunzipSync } from "node:zlib";
 import { staticMiddleware } from "srvx/static";
 import type { Environment } from "vite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -191,6 +191,26 @@ describe("repeat passes over one directory", () => {
     await precompressDir(dir, ALL);
     expect(brotliDecompressSync(await readFile(join(dir, "app.js.br"))).toString()).toBe(changed);
     expect(gunzipSync(await readFile(join(dir, "app.js.gz"))).toString()).toBe(changed);
+  });
+
+  it("retires variants that no longer meet a raised threshold", async () => {
+    await writeFile(join(dir, "app.js"), "x".repeat(4096));
+    await precompressDir(dir, resolvePrecompress({ threshold: 0 }) as ResolvedPrecompress);
+    // The variants still decode to the identity, so byte correspondence alone would keep
+    // them — but this build's policy no longer wants them at all.
+    await precompressDir(dir, resolvePrecompress({ threshold: 8192 }) as ResolvedPrecompress);
+    expect(await exists(join(dir, "app.js.br"))).toBe(false);
+    expect(await exists(join(dir, "app.js.gz"))).toBe(false);
+  });
+
+  it("replaces a correspondent variant that is not smaller than its identity", async () => {
+    const brOnly = resolvePrecompress({ threshold: 0, encodings: ["br"] }) as ResolvedPrecompress;
+    await writeFile(join(dir, "tiny.js"), "x");
+    // Valid brotli that decodes to the identity, yet larger than it. srvx compares nothing,
+    // so serving this would make the response bigger.
+    await writeFile(join(dir, "tiny.js.br"), brotliCompressSync(Buffer.from("x")));
+    await precompressDir(dir, brOnly);
+    expect(await exists(join(dir, "tiny.js.br"))).toBe(false);
   });
 
   it("the reported count matches the variants actually written", async () => {

--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -60,11 +60,17 @@ afterEach(async () => {
   await rm(dir, { recursive: true, force: true });
 });
 
-const exists = (path: string) =>
-  stat(path).then(
-    () => true,
-    () => false,
-  );
+/** Absence, and only absence. A permission or I/O error would otherwise read as "not
+ *  there" and let a negative assertion pass without the file being gone. */
+const exists = async (path: string) => {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+};
 
 async function request(options: ResolvedStaticOptions, encoding: string) {
   const middleware = staticMiddleware(options);
@@ -126,12 +132,14 @@ describe("repeat passes over one directory", () => {
   it("a second pass does no work — emission runs once per environment", async () => {
     await writeFile(join(dir, "app.js"), COMPRESSIBLE);
     const first = await precompressDir(dir, ALL);
-    const before = (await stat(join(dir, "app.js.br"))).mtimeMs;
+    // Backdate the variant to a sentinel far outside timer resolution: a rewrite would
+    // replace it with "now", so its survival is unambiguous evidence of no rewrite.
+    const sentinel = new Date(Date.now() - 60_000);
+    await utimes(join(dir, "app.js.br"), sentinel, sentinel);
     const second = await precompressDir(dir, ALL);
     expect(first.written).toBe(2);
     expect(second.written).toBe(0);
-    // Not merely "reported nothing": the file was not rewritten either.
-    expect((await stat(join(dir, "app.js.br"))).mtimeMs).toBe(before);
+    expect((await stat(join(dir, "app.js.br"))).mtimeMs).toBe(sentinel.getTime());
   });
 
   it("a file written between passes is still covered", async () => {

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -93,11 +93,8 @@ export function encodingsMap(resolved: ResolvedPrecompress): Record<string, stri
   return Object.fromEntries(resolved.encodings.map((name) => [name, CODECS[name].ext]));
 }
 
-/**
- * Read a file that may legitimately have vanished since the walk listed it. Only ENOENT is
- * benign: a permission or I/O error means the tree is not what it appears to be, and
- * treating that as "absent" would leave whatever variants are already beside it.
- */
+/** A file can vanish between the walk listing it and this read. Only ENOENT is benign —
+ *  reading any other error as "absent" would leave the variants beside it in place. */
 async function readIfPresent(path: string): Promise<Buffer | null> {
   try {
     return await readFile(path);
@@ -107,13 +104,7 @@ async function readIfPresent(path: string): Promise<Buffer | null> {
   }
 }
 
-/**
- * The one size rule: a variant may not be larger than its identity. srvx compares nothing,
- * so a larger variant would be served and would make the response bigger — that is the
- * whole hazard, and an equal-sized variant does not cause it: the wire cost is identical
- * and the request still avoids on-the-fly compression. Used both to accept a fresh encode
- * and to accept one already on disk, so the two cannot drift apart.
- */
+/** srvx compares no sizes: whatever variant is on disk is what it serves. */
 function notLarger(source: Buffer, variant: Buffer): boolean {
   return variant.length <= source.length;
 }
@@ -146,30 +137,17 @@ export async function collectRelativeFiles(dir: string): Promise<Set<string>> {
 }
 
 export interface PrecompressContext {
-  /**
-   * Paths copied verbatim from `publicDir`, relative to the served directory with `/`
-   * separators. Those files are re-copied from source every build, so this build's
-   * output can never go stale beside them: their variants are the user's, and are
-   * neither emitted nor retired here.
-   */
+  /** Paths under `publicDir`, relative to the served directory with `/` separators. They
+   *  are re-copied from source every build, so their variants are the user's. */
   passThrough?: ReadonlySet<string>;
 }
 
-/**
- * Whether every configured variant decodes to exactly the identity beside it.
- *
- * Only the decoded bytes decide. File metadata cannot: a timestamp is not a content
- * correspondence, and a cache restore, an archive extraction or a timestamp-preserving
- * copy can leave a changed identity whose mtime still predates its variant. Trusting that
- * would serve the old body under the new file's URL — the hazard this walk exists to
- * prevent, not an optimization. A missing variant, a decode failure, or any difference
- * means reconcile.
- */
+/** Whether every configured variant decodes to exactly the identity beside it. A missing
+ *  variant, a decode failure, or any difference means reconcile. */
 async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
   for (const encoding of resolved.encodings) {
     const codec = CODECS[encoding];
-    // Unreadable for any reason means not usable as-is; the reconcile path below then
-    // deals with it and reports accurately if it cannot be removed.
+    // Unreadable for any reason means not usable as-is — the reconcile loop then deals with it.
     const bytes = await readFile(filePath + codec.ext).catch(() => null);
     if (!bytes || !notLarger(source, bytes)) return false;
     const decoded = await codec.decode(bytes).catch(() => null);
@@ -191,10 +169,8 @@ async function processFile(
   if (!source) return 0;
 
   const eligible = source.length >= resolved.threshold;
-  // Emission runs once per environment, so a multi-environment build walks the same
-  // directory more than once; without this, every later pass re-encodes what the first
-  // already did. Eligibility is decided FIRST: a file this build would not compress must
-  // reach the reconcile path below, or a variant left by a lower threshold would survive.
+  // Eligibility first: an ineligible file must reach the reconcile loop, or a variant left
+  // by a lower threshold would survive.
   if (eligible && (await isCurrent(filePath, source, resolved))) return 0;
 
   let written = 0;
@@ -209,9 +185,8 @@ async function processFile(
         continue;
       }
     }
-    // Anything this build did not write is removed: a leftover beside a file whose
-    // contents or eligibility changed is how stale bytes get served. `force` ignores an
-    // absent variant and rejects a real failure, which must stop the build.
+    // A leftover beside a changed file is how stale bytes get served, so a retire that
+    // fails is not swallowed: it stops the build.
     await rm(variantPath, { force: true });
   }
   return written;

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -251,9 +251,9 @@ const MEMO_KEY = Symbol.for(`@universal-deploy/node precompress memo v${MEMO_CON
 const globalScope = globalThis as unknown as Record<symbol, Map<string, string> | undefined>;
 
 /**
- * What this build has already reconciled, by absolute path. Keyed on **content**, never on
- * the path alone: a later environment may rewrite a file an earlier pass handled, and a
- * path-keyed memo would skip it and leave the earlier bytes' variants in place.
+ * What has already been reconciled, by absolute path. Keyed on **content**, never on the path
+ * alone: a later environment may rewrite a file an earlier pass handled, and a path-keyed memo
+ * would skip it and leave the earlier bytes' variants in place.
  *
  * On `globalThis` rather than module scope, which is per module **instance**: dual resolution or
  * two installed versions put more than one copy of this module in one process, and a per-copy
@@ -261,10 +261,3 @@ const globalScope = globalThis as unknown as Record<symbol, Map<string, string> 
  */
 const reconciled = globalScope[MEMO_KEY] ?? new Map<string, string>();
 globalScope[MEMO_KEY] = reconciled;
-
-/** A later build may empty the output directory, so a record that outlived one would claim a
- *  reconciliation whose variants are no longer there. Cleared during config resolution, before
- *  any environment `buildStart`. */
-export function forgetReconciled(): void {
-  reconciled.clear();
-}

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -1,4 +1,5 @@
-import { readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { extname, join, posix, sep } from "node:path";
 import { promisify } from "node:util";
 import { brotliCompress, brotliDecompress, constants, gunzip, gzip } from "node:zlib";
@@ -148,9 +149,16 @@ export interface PrecompressContext {
   passThrough?: ReadonlySet<string>;
 }
 
+/**
+ * Source bytes this process has already reconciled, by absolute path. Keyed on **content**,
+ * never on the path alone: a later environment may rewrite a file an earlier pass handled,
+ * and a path-keyed memo would skip it and leave the earlier bytes' variants in place.
+ */
+const reconciled = new Map<string, string>();
+
 /** Whether every configured variant decodes to exactly the identity beside it. A missing
  *  variant, a decode failure, or any difference means reconcile. */
-async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
+async function decodesToSource(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
   for (const encoding of resolved.encodings) {
     const codec = CODECS[encoding];
     // Unreadable for any reason means not usable as-is — the reconcile loop then deals with it.
@@ -160,6 +168,40 @@ async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPre
     if (!decoded || !decoded.equals(source)) return false;
   }
   return true;
+}
+
+/** The memo says what we wrote, not what is on disk — so presence is still checked. Anything
+ *  that removed a variant since (a cleaned output directory, a rebuild in the same process)
+ *  falls through and re-emits. */
+async function variantsPresent(filePath: string, resolved: ResolvedPrecompress): Promise<boolean> {
+  for (const encoding of resolved.encodings) {
+    const there = await stat(filePath + CODECS[encoding].ext).then(
+      () => true,
+      () => false,
+    );
+    if (!there) return false;
+  }
+  return true;
+}
+
+/**
+ * Whether this file's variants are already correct. A memo hit costs one hash and one `stat`
+ * per encoding; a miss falls through to decoding every variant, which is ~7x dearer per file
+ * and is what every extra environment would otherwise pay for the whole asset set.
+ */
+async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
+  const digest = createHash("sha256").update(source).digest("hex");
+  if (reconciled.get(filePath) === digest) return variantsPresent(filePath, resolved);
+
+  const current = await decodesToSource(filePath, source, resolved);
+  if (current) reconciled.set(filePath, digest);
+  return current;
+}
+
+/** Record that these exact bytes were reconciled, so later passes skip on a hash instead of
+ *  a decode. */
+function remember(filePath: string, source: Buffer): void {
+  reconciled.set(filePath, createHash("sha256").update(source).digest("hex"));
 }
 
 /** Whether the variants beside this file are ours to write and remove. */
@@ -211,7 +253,9 @@ async function processFile(
   // lower threshold would survive.
   if (eligible && (await isCurrent(filePath, source, resolved))) return 0;
 
-  return reconcile(filePath, source, eligible, resolved);
+  const written = await reconcile(filePath, source, eligible, resolved);
+  if (eligible) remember(filePath, source);
+  return written;
 }
 
 /**

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -1,8 +1,7 @@
-import type { Stats } from "node:fs";
 import { readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { extname, join, posix, sep } from "node:path";
 import { promisify } from "node:util";
-import { brotliCompress, constants, gzip } from "node:zlib";
+import { brotliCompress, brotliDecompress, constants, gunzip, gzip } from "node:zlib";
 
 export type PrecompressEncoding = "br" | "gzip";
 
@@ -43,6 +42,8 @@ const CONCURRENCY = 4;
 
 const brotliAsync = promisify(brotliCompress);
 const gzipAsync = promisify(gzip);
+const brotliDecompressAsync = promisify(brotliDecompress);
+const gunzipAsync = promisify(gunzip);
 
 /** `undefined` when precompression is off — the single off-switch. */
 export function resolvePrecompress(
@@ -74,6 +75,10 @@ function encode(encoding: PrecompressEncoding, source: Buffer): Promise<Buffer> 
         },
       })
     : gzipAsync(source, { level: constants.Z_BEST_COMPRESSION });
+}
+
+function decode(encoding: PrecompressEncoding, bytes: Buffer): Promise<Buffer> {
+  return encoding === "br" ? brotliDecompressAsync(bytes) : gunzipAsync(bytes);
 }
 
 /**
@@ -126,19 +131,21 @@ export interface PrecompressContext {
 }
 
 /**
- * Whether every variant already post-dates its identity, in which case some earlier pass
- * — this build's or a previous one's — already reconciled this file.
+ * Whether every configured variant decodes to exactly the identity beside it.
  *
- * This is **not** the forbidden skip-if-a-variant-exists: existence says nothing about
- * whether the variant matches the identity beside it, which is how a stale variant from a
- * previous build survives a content change. A rewritten identity always carries a newer
- * mtime than the variant made from its previous contents, so it is never skipped here. A
- * tie, or a missing variant, falls through to doing the work.
+ * Only the decoded bytes decide. File metadata cannot: a timestamp is not a content
+ * correspondence, and a cache restore, an archive extraction or a timestamp-preserving
+ * copy can leave a changed identity whose mtime still predates its variant. Trusting that
+ * would serve the old body under the new file's URL — the hazard this walk exists to
+ * prevent, not an optimization. A missing variant, a decode failure, or any difference
+ * means reconcile.
  */
-async function isCurrent(filePath: string, identity: Stats, resolved: ResolvedPrecompress): Promise<boolean> {
+async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
   for (const encoding of resolved.encodings) {
-    const variant = await stat(filePath + VARIANT_EXT[encoding]).catch(() => null);
-    if (!variant || variant.mtimeMs <= identity.mtimeMs) return false;
+    const bytes = await readFile(filePath + VARIANT_EXT[encoding]).catch(() => null);
+    if (!bytes) return false;
+    const decoded = await decode(encoding, bytes).catch(() => null);
+    if (!decoded || !decoded.equals(source)) return false;
   }
   return true;
 }
@@ -152,14 +159,13 @@ async function processFile(
   if (!NEGOTIABLE.has(extname(filePath).toLowerCase())) return 0;
   if (context.passThrough?.has(relPath)) return 0;
 
-  const identity = await stat(filePath).catch(() => null);
-  if (!identity) return 0;
+  const source = await readFile(filePath).catch(() => null);
+  if (!source) return 0;
   // Emission runs once per environment, so a multi-environment build walks the same
   // directory more than once. Without this, every pass after the first would re-encode
   // everything the earlier ones already did.
-  if (await isCurrent(filePath, identity, resolved)) return 0;
+  if (await isCurrent(filePath, source, resolved)) return 0;
 
-  const source = await readFile(filePath);
   const eligible = source.length >= resolved.threshold;
 
   let written = 0;

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { extname, join, posix, sep } from "node:path";
 import { promisify } from "node:util";
 import { brotliCompress, brotliDecompress, constants, gunzip, gzip } from "node:zlib";
@@ -154,11 +154,15 @@ interface Reconciled {
   /** The configured encodings at the time, so a differently-configured pass cannot hit. */
   under: string;
   /**
-   * Suffixes the pass wrote. **Empty is a value, not a missing entry:** it records that these
-   * bytes yield no variant — a conclusion reached only by encoding at full quality, which is
-   * the most expensive thing the walk does and the one worth never repeating.
+   * Digest of the bytes written for each suffix. A configured suffix **absent from this map**
+   * was deliberately not written, and a later pass must prove it is still absent — an entry
+   * existing is not evidence the entry is ours.
    */
-  wrote: readonly string[];
+  wrote: ReadonlyMap<string, string>;
+}
+
+function digestOf(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
 }
 
 /**
@@ -168,65 +172,87 @@ interface Reconciled {
  */
 const reconciled = new Map<string, Reconciled>();
 
-/** Whether every configured variant decodes to exactly the identity beside it. A missing
- *  variant, a decode failure, or any difference means reconcile. */
-async function decodesToSource(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
+/**
+ * The digests of every configured variant, when each one decodes to exactly the identity
+ * beside it — `null` when any is missing, undecodable, or different. Returning the digests
+ * rather than a flag lets a directory that was already correct be recorded without a second
+ * read: the bytes were in hand anyway.
+ */
+async function decodesToSource(
+  filePath: string,
+  source: Buffer,
+  resolved: ResolvedPrecompress,
+): Promise<Map<string, string> | null> {
+  const digests = new Map<string, string>();
   for (const encoding of resolved.encodings) {
     const codec = CODECS[encoding];
     // Unreadable for any reason means not usable as-is — the reconcile loop then deals with it.
     const bytes = await readFile(filePath + codec.ext).catch(() => null);
-    if (!bytes || !notLarger(source, bytes)) return false;
+    if (!bytes || !notLarger(source, bytes)) return null;
     const decoded = await codec.decode(bytes).catch(() => null);
-    if (!decoded || !decoded.equals(source)) return false;
+    if (!decoded || !decoded.equals(source)) return null;
+    digests.set(codec.ext, digestOf(bytes));
   }
-  return true;
+  return digests;
 }
 
-/** The memo says what we wrote, not what is on disk — so presence is still checked. Anything
- *  that removed a variant since (a cleaned output directory, a rebuild in the same process)
- *  falls through and re-emits. */
-async function allPresent(filePath: string, suffixes: readonly string[]): Promise<boolean> {
-  for (const suffix of suffixes) {
-    const there = await stat(filePath + suffix).then(
-      () => true,
-      () => false,
-    );
-    if (!there) return false;
+/**
+ * Whether every configured suffix still matches what the recorded pass left: the same bytes
+ * where one was written, and nothing at all where one was not.
+ *
+ * Both halves are load-bearing. srvx serves an adjacent variant without comparing it to the
+ * identity, so a variant that is present-but-altered, or present where reconciliation removed
+ * one, is wrong bytes on a live URL. A directory entry existing is not evidence it is ours.
+ */
+async function matchesRecord(
+  filePath: string,
+  resolved: ResolvedPrecompress,
+  wrote: ReadonlyMap<string, string>,
+): Promise<boolean> {
+  for (const encoding of resolved.encodings) {
+    const suffix = CODECS[encoding].ext;
+    // `readIfPresent`, not a swallowing catch: only ENOENT may count as absent. Reading
+    // EACCES or EIO as "nothing there" would make the absence proof vacuous on exactly the
+    // machines where it matters, and pass every test a healthy filesystem can run.
+    const bytes = await readIfPresent(filePath + suffix);
+    const expected = wrote.get(suffix);
+    if (expected === undefined) {
+      if (bytes) return false;
+    } else if (!bytes || digestOf(bytes) !== expected) {
+      return false;
+    }
   }
   return true;
 }
 
 /**
- * Whether this file's variants are already correct. A memo hit costs one hash and a `stat`
- * for each variant the pass wrote — none at all for bytes that yield no variant; a miss falls
- * through to decoding every variant, which is what every extra environment would otherwise pay
- * for the whole asset set.
+ * Whether this file's variants are already correct. A memo hit reads each variant and hashes
+ * it; a miss decodes them instead. Hashing the stored representation is far cheaper than
+ * decompressing it, which is where the saving comes from — not from checking less.
  */
 async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
-  const digest = createHash("sha256").update(source).digest("hex");
+  const digest = digestOf(source);
   const memo = reconciled.get(filePath);
-  if (memo?.digest === digest && memo.under === resolved.encodings.join()) return allPresent(filePath, memo.wrote);
+  if (memo?.digest === digest && memo.under === resolved.encodings.join()) {
+    if (await matchesRecord(filePath, resolved, memo.wrote)) return true;
+  }
 
-  const current = await decodesToSource(filePath, source, resolved);
-  // Every configured variant just decoded to the source, so all of them are on disk.
-  if (current)
-    remember(
-      filePath,
-      source,
-      resolved,
-      resolved.encodings.map((e) => CODECS[e].ext),
-    );
-  return current;
+  // A directory that was already correct on entry — an incremental rebuild — is recorded here
+  // too, so the environments after this one verify by hash rather than decoding again.
+  const verified = await decodesToSource(filePath, source, resolved);
+  if (verified) remember(filePath, source, resolved, verified);
+  return verified !== null;
 }
 
-/** Record what these exact bytes reconciled to, so later passes skip on a hash instead of a
- *  decode — or, when nothing was written, without touching the disk at all. */
-function remember(filePath: string, source: Buffer, resolved: ResolvedPrecompress, wrote: readonly string[]): void {
-  reconciled.set(filePath, {
-    digest: createHash("sha256").update(source).digest("hex"),
-    under: resolved.encodings.join(),
-    wrote,
-  });
+/** Record what these exact bytes reconciled to, so later passes verify by hash rather than by
+ *  decode. Only `reconcile` records: it is the one place that knows what was written. */
+function remember(
+  filePath: string,
+  source: Buffer,
+  resolved: ResolvedPrecompress,
+  wrote: ReadonlyMap<string, string>,
+): void {
+  reconciled.set(filePath, { digest: digestOf(source), under: resolved.encodings.join(), wrote });
 }
 
 /** Whether the variants beside this file are ours to write and remove. */
@@ -242,8 +268,8 @@ async function reconcile(
   source: Buffer,
   eligible: boolean,
   resolved: ResolvedPrecompress,
-): Promise<string[]> {
-  const wrote: string[] = [];
+): Promise<Map<string, string>> {
+  const wrote = new Map<string, string>();
   for (const encoding of resolved.encodings) {
     const codec = CODECS[encoding];
     const variantPath = filePath + codec.ext;
@@ -251,7 +277,9 @@ async function reconcile(
       const encoded = await codec.encode(source);
       if (notLarger(source, encoded)) {
         await writeFile(variantPath, encoded);
-        wrote.push(codec.ext);
+        // Digested here, while the buffer is already in hand: free at write time, and it is
+        // what lets a later pass verify by hash instead of by decode.
+        wrote.set(codec.ext, digestOf(encoded));
         continue;
       }
     }
@@ -280,7 +308,7 @@ async function processFile(
 
   const wrote = await reconcile(filePath, source, eligible, resolved);
   if (eligible) remember(filePath, source, resolved, wrote);
-  return wrote.length;
+  return wrote.size;
 }
 
 /**

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -150,19 +150,36 @@ export interface PrecompressContext {
 }
 
 interface Reconciled {
+  /** The source bytes. Compared first, so a changed file is a miss without reading a variant. */
   digest: string;
-  /** The configured encodings at the time, so a differently-configured pass cannot hit. */
-  under: string;
   /**
-   * Digest of the bytes written for each suffix. A configured suffix **absent from this map**
-   * was deliberately not written, and a later pass must prove it is still absent — an entry
-   * existing is not evidence the entry is ours.
+   * One digest over the configured encodings and what each suffix held. A planted or altered
+   * variant misses because its own digest enters the fold. The empty marker buys the widening
+   * case: without a term for a suffix nothing was written to, a pass configured with one
+   * encoding and a pass configured with two that wrote only the first fold identically.
    */
-  wrote: ReadonlyMap<string, string>;
+  variants: string;
 }
 
 function digestOf(bytes: Buffer): string {
   return createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * Fold the configured encodings and each suffix's digest into one value. `held` returns the
+ * digest of what a suffix holds, or `undefined` for nothing — and a digest is never empty, so
+ * the empty marker cannot collide with one.
+ */
+function foldVariants(resolved: ResolvedPrecompress, held: (suffix: string) => string | undefined): string {
+  const composite = createHash("sha256");
+  for (const encoding of resolved.encodings) {
+    composite
+      .update(encoding)
+      .update("\0")
+      .update(held(CODECS[encoding].ext) ?? "")
+      .update("\0");
+  }
+  return composite.digest("hex");
 }
 
 /**
@@ -204,25 +221,17 @@ async function decodesToSource(
  * identity, so a variant that is present-but-altered, or present where reconciliation removed
  * one, is wrong bytes on a live URL. A directory entry existing is not evidence it is ours.
  */
-async function matchesRecord(
-  filePath: string,
-  resolved: ResolvedPrecompress,
-  wrote: ReadonlyMap<string, string>,
-): Promise<boolean> {
+async function matchesRecord(filePath: string, resolved: ResolvedPrecompress, expected: string): Promise<boolean> {
+  const onDisk = new Map<string, string>();
   for (const encoding of resolved.encodings) {
     const suffix = CODECS[encoding].ext;
     // `readIfPresent`, not a swallowing catch: only ENOENT may count as absent. Reading
     // EACCES or EIO as "nothing there" would make the absence proof vacuous on exactly the
     // machines where it matters, and pass every test a healthy filesystem can run.
     const bytes = await readIfPresent(filePath + suffix);
-    const expected = wrote.get(suffix);
-    if (expected === undefined) {
-      if (bytes) return false;
-    } else if (!bytes || digestOf(bytes) !== expected) {
-      return false;
-    }
+    if (bytes) onDisk.set(suffix, digestOf(bytes));
   }
-  return true;
+  return foldVariants(resolved, (suffix) => onDisk.get(suffix)) === expected;
 }
 
 /**
@@ -233,9 +242,8 @@ async function matchesRecord(
 async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
   const digest = digestOf(source);
   const memo = reconciled.get(filePath);
-  if (memo?.digest === digest && memo.under === resolved.encodings.join()) {
-    if (await matchesRecord(filePath, resolved, memo.wrote)) return true;
-  }
+  // Source digest first: a changed file misses without reading a single variant.
+  if (memo?.digest === digest && (await matchesRecord(filePath, resolved, memo.variants))) return true;
 
   // For a directory that was already correct, this is the only place an entry is ever written:
   // returning true here makes `processFile` return before reaching its own `remember`. Delete
@@ -253,7 +261,10 @@ function remember(
   resolved: ResolvedPrecompress,
   wrote: ReadonlyMap<string, string>,
 ): void {
-  reconciled.set(filePath, { digest: digestOf(source), under: resolved.encodings.join(), wrote });
+  reconciled.set(filePath, {
+    digest: digestOf(source),
+    variants: foldVariants(resolved, (suffix) => wrote.get(suffix)),
+  });
 }
 
 /** Whether the variants beside this file are ours to write and remove. */

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -1,3 +1,4 @@
+import type { Stats } from "node:fs";
 import { readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { extname, join, posix, sep } from "node:path";
 import { promisify } from "node:util";
@@ -124,6 +125,24 @@ export interface PrecompressContext {
   passThrough?: ReadonlySet<string>;
 }
 
+/**
+ * Whether every variant already post-dates its identity, in which case some earlier pass
+ * — this build's or a previous one's — already reconciled this file.
+ *
+ * This is **not** the forbidden skip-if-a-variant-exists: existence says nothing about
+ * whether the variant matches the identity beside it, which is how a stale variant from a
+ * previous build survives a content change. A rewritten identity always carries a newer
+ * mtime than the variant made from its previous contents, so it is never skipped here. A
+ * tie, or a missing variant, falls through to doing the work.
+ */
+async function isCurrent(filePath: string, identity: Stats, resolved: ResolvedPrecompress): Promise<boolean> {
+  for (const encoding of resolved.encodings) {
+    const variant = await stat(filePath + VARIANT_EXT[encoding]).catch(() => null);
+    if (!variant || variant.mtimeMs <= identity.mtimeMs) return false;
+  }
+  return true;
+}
+
 async function processFile(
   filePath: string,
   relPath: string,
@@ -132,6 +151,13 @@ async function processFile(
 ): Promise<number> {
   if (!NEGOTIABLE.has(extname(filePath).toLowerCase())) return 0;
   if (context.passThrough?.has(relPath)) return 0;
+
+  const identity = await stat(filePath).catch(() => null);
+  if (!identity) return 0;
+  // Emission runs once per environment, so a multi-environment build walks the same
+  // directory more than once. Without this, every pass after the first would re-encode
+  // everything the earlier ones already did.
+  if (await isCurrent(filePath, identity, resolved)) return 0;
 
   const source = await readFile(filePath);
   const eligible = source.length >= resolved.threshold;
@@ -180,7 +206,8 @@ export async function precompressDir(
     for (let i = next++; i < files.length; i = next++) {
       const filePath = files[i] as string;
       const relPath = filePath.slice(prefix).split(sep).join(posix.sep);
-      written += await processFile(filePath, relPath, resolved, context);
+      const count = await processFile(filePath, relPath, resolved, context);
+      written += count;
     }
   };
   await Promise.all(Array.from({ length: Math.min(CONCURRENCY, files.length) }, worker));

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -289,7 +289,7 @@ async function reconcile(
       const encoded = await codec.encode(source);
       if (notLarger(source, encoded)) {
         await writeFile(variantPath, encoded);
-        // Digested here, while the buffer is already in hand: free at write time, and it is
+        // Digested here, while the buffer is already in hand — no second read — and it is
         // what lets a later pass verify by hash instead of by decode.
         wrote.set(codec.ext, digestOf(encoded));
         continue;

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -1,0 +1,189 @@
+import { readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { extname, join, posix, sep } from "node:path";
+import { promisify } from "node:util";
+import { brotliCompress, constants, gzip } from "node:zlib";
+
+export type PrecompressEncoding = "br" | "gzip";
+
+export interface PrecompressOptions {
+  /**
+   * Encodings to emit, in server-preference order: the first one the client accepts
+   * wins. This order is also the order baked into srvx's `encodings` map.
+   *
+   * @default ["br", "gzip"]
+   */
+  encodings?: PrecompressEncoding[];
+  /**
+   * Minimum size, in bytes, of the original file. No upper bound: precompression is
+   * the only way to compress a file past srvx's 10 MiB on-the-fly ceiling.
+   *
+   * @default 1024
+   */
+  threshold?: number;
+}
+
+export interface ResolvedPrecompress {
+  encodings: PrecompressEncoding[];
+  threshold: number;
+}
+
+/**
+ * Extensions srvx negotiates an encoding for: the entries of its `COMMON_MIME_TYPES`
+ * whose type passes its `isCompressible()`. A variant outside this set can never be
+ * served, so emitting one would be dead bytes on disk.
+ */
+const NEGOTIABLE = new Set([".css", ".htm", ".html", ".js", ".json", ".mjs", ".svg", ".txt", ".wasm", ".xml"]);
+
+const VARIANT_EXT: Record<PrecompressEncoding, string> = { br: ".br", gzip: ".gz" };
+
+// `node:zlib`'s async calls run on libuv's threadpool, which defaults to 4 workers;
+// queueing past it buys no parallelism while multiplying peak memory.
+const CONCURRENCY = 4;
+
+const brotliAsync = promisify(brotliCompress);
+const gzipAsync = promisify(gzip);
+
+/** `undefined` when precompression is off — the single off-switch. */
+export function resolvePrecompress(
+  configured: boolean | PrecompressOptions | undefined,
+): ResolvedPrecompress | undefined {
+  if (!configured) return undefined;
+  const options = configured === true ? {} : configured;
+  return {
+    encodings: options.encodings ?? ["br", "gzip"],
+    threshold: options.threshold ?? 1024,
+  };
+}
+
+/**
+ * The `encodings` map handed to srvx. Insertion order is srvx's server preference and
+ * beats the client's `Accept-Encoding` order, so it must follow `encodings`.
+ */
+export function encodingsMap(resolved: ResolvedPrecompress): Record<string, string> {
+  return Object.fromEntries(resolved.encodings.map((name) => [name, VARIANT_EXT[name]]));
+}
+
+function encode(encoding: PrecompressEncoding, source: Buffer): Promise<Buffer> {
+  return encoding === "br"
+    ? brotliAsync(source, {
+        params: {
+          // Build time, once — the whole point of not paying it per request.
+          [constants.BROTLI_PARAM_QUALITY]: constants.BROTLI_MAX_QUALITY,
+          [constants.BROTLI_PARAM_SIZE_HINT]: source.length,
+        },
+      })
+    : gzipAsync(source, { level: constants.Z_BEST_COMPRESSION });
+}
+
+/**
+ * Remove a variant this build did not write. A failed unlink is not an unlink, so an
+ * unremovable variant is fatal rather than a warning: leaving it would let srvx serve
+ * stale bytes as the current file's body.
+ */
+async function retire(variantPath: string): Promise<void> {
+  await rm(variantPath, { force: true }).catch(() => {});
+  const survivor = await stat(variantPath).catch(() => null);
+  if (survivor) {
+    throw new Error(
+      `[ud:node:precompress] could not remove the stale variant ${variantPath}. ` +
+        `Leaving it would let it be served as the current file's body.`,
+    );
+  }
+}
+
+/** Every file under `dir`, as absolute paths. Nothing is filtered here — extensions are
+ *  a per-file decision, never a traversal filter. */
+async function collectFiles(dir: string): Promise<string[]> {
+  const found: string[] = [];
+  const walk = async (current: string): Promise<void> => {
+    const entries = await readdir(current, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) await walk(full);
+      else if (entry.isFile()) found.push(full);
+    }
+  };
+  await walk(dir);
+  return found;
+}
+
+/** Paths under `dir`, relative to it and with `/` separators. */
+export async function collectRelativeFiles(dir: string): Promise<Set<string>> {
+  const files = await collectFiles(dir);
+  const prefix = dir.endsWith(sep) ? dir.length : dir.length + 1;
+  return new Set(files.map((file) => file.slice(prefix).split(sep).join(posix.sep)));
+}
+
+export interface PrecompressContext {
+  /**
+   * Paths copied verbatim from `publicDir`, relative to the served directory with `/`
+   * separators. Those files are re-copied from source every build, so this build's
+   * output can never go stale beside them: their variants are the user's, and are
+   * neither emitted nor retired here.
+   */
+  passThrough?: ReadonlySet<string>;
+}
+
+async function processFile(
+  filePath: string,
+  relPath: string,
+  resolved: ResolvedPrecompress,
+  context: PrecompressContext,
+): Promise<number> {
+  if (!NEGOTIABLE.has(extname(filePath).toLowerCase())) return 0;
+  if (context.passThrough?.has(relPath)) return 0;
+
+  const source = await readFile(filePath);
+  const eligible = source.length >= resolved.threshold;
+
+  let written = 0;
+  for (const encoding of resolved.encodings) {
+    const variantPath = filePath + VARIANT_EXT[encoding];
+    let emitted = false;
+    if (eligible) {
+      const encoded = await encode(encoding, source);
+      // srvx compares nothing: a variant larger than its identity would be served and
+      // would make the response bigger.
+      if (encoded.length < source.length) {
+        await writeFile(variantPath, encoded);
+        emitted = true;
+        written++;
+      }
+    }
+    // Rewritten on every build, never skipped — a skip is how a stale variant survives
+    // a content change.
+    if (!emitted) await retire(variantPath);
+  }
+  return written;
+}
+
+export interface PrecompressResult {
+  scanned: number;
+  written: number;
+}
+
+/**
+ * Emit `.br`/`.gz` variants beside the eligible files under `dir`, and retire the
+ * current encodings' variants beside the ones that got none.
+ */
+export async function precompressDir(
+  dir: string,
+  resolved: ResolvedPrecompress,
+  context: PrecompressContext = {},
+): Promise<PrecompressResult> {
+  const files = await collectFiles(dir);
+  const prefix = dir.endsWith(sep) ? dir.length : dir.length + 1;
+
+  let next = 0;
+  let written = 0;
+  const worker = async (): Promise<void> => {
+    for (let i = next++; i < files.length; i = next++) {
+      const filePath = files[i] as string;
+      const relPath = filePath.slice(prefix).split(sep).join(posix.sep);
+      written += await processFile(filePath, relPath, resolved, context);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, files.length) }, worker));
+
+  return { scanned: files.length, written };
+}

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { extname, join, posix, sep } from "node:path";
 import { promisify } from "node:util";
 import { brotliCompress, brotliDecompress, constants, gunzip, gzip } from "node:zlib";
@@ -52,7 +52,9 @@ export function resolvePrecompress(
   if (!configured) return undefined;
   const options = configured === true ? {} : configured;
   return {
-    encodings: options.encodings ?? ["br", "gzip"],
+    // Deduplicated, insertion-ordered: a repeated encoding would re-encode and rewrite
+    // the same path and inflate the reported count, while `encodingsMap` collapses it anyway.
+    encodings: [...new Set<PrecompressEncoding>(options.encodings ?? ["br", "gzip"])],
     threshold: options.threshold ?? 1024,
   };
 }
@@ -104,25 +106,6 @@ async function readIfPresent(path: string): Promise<Buffer | null> {
  */
 function notLarger(source: Buffer, variant: Buffer): boolean {
   return variant.length <= source.length;
-}
-
-/**
- * Remove a variant this build did not write. A failed unlink is not an unlink, so an
- * unremovable variant is fatal rather than a warning: leaving it would let srvx serve
- * stale bytes as the current file's body.
- */
-async function retire(variantPath: string): Promise<void> {
-  await rm(variantPath, { force: true }).catch(() => {});
-  const survivor = await stat(variantPath).catch((error: NodeJS.ErrnoException) => {
-    if (error.code === "ENOENT") return null;
-    throw error;
-  });
-  if (survivor) {
-    throw new Error(
-      `[ud:node:precompress] could not remove the stale variant ${variantPath}. ` +
-        `Leaving it would let it be served as the current file's body.`,
-    );
-  }
 }
 
 /** Every file under `dir`, as absolute paths. Nothing is filtered here — extensions are
@@ -206,25 +189,20 @@ async function processFile(
   let written = 0;
   for (const encoding of resolved.encodings) {
     const variantPath = filePath + VARIANT_EXT[encoding];
-    let emitted = false;
     if (eligible) {
       const encoded = await encode(encoding, source);
       if (notLarger(source, encoded)) {
         await writeFile(variantPath, encoded);
-        emitted = true;
         written++;
+        continue;
       }
     }
-    // Every variant this build did not write is removed: a leftover beside a file whose
-    // contents or eligibility changed is how stale bytes get served.
-    if (!emitted) await retire(variantPath);
+    // Anything this build did not write is removed: a leftover beside a file whose
+    // contents or eligibility changed is how stale bytes get served. `force` ignores an
+    // absent variant and rejects a real failure, which must stop the build.
+    await rm(variantPath, { force: true });
   }
   return written;
-}
-
-export interface PrecompressResult {
-  scanned: number;
-  written: number;
 }
 
 /**
@@ -235,15 +213,15 @@ export async function precompressDir(
   dir: string,
   resolved: ResolvedPrecompress,
   context: PrecompressContext = {},
-): Promise<PrecompressResult> {
+): Promise<{ written: number }> {
   const files = await collectFiles(dir);
   const prefix = dir.endsWith(sep) ? dir.length : dir.length + 1;
 
   let next = 0;
   let written = 0;
   const worker = async (): Promise<void> => {
-    for (let i = next++; i < files.length; i = next++) {
-      const filePath = files[i] as string;
+    while (next < files.length) {
+      const filePath = files[next++] as string;
       const relPath = filePath.slice(prefix).split(sep).join(posix.sep);
       const count = await processFile(filePath, relPath, resolved, context);
       written += count;
@@ -251,5 +229,5 @@ export async function precompressDir(
   };
   await Promise.all(Array.from({ length: Math.min(CONCURRENCY, files.length) }, worker));
 
-  return { scanned: files.length, written };
+  return { written };
 }

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -149,12 +149,24 @@ export interface PrecompressContext {
   passThrough?: ReadonlySet<string>;
 }
 
+interface Reconciled {
+  digest: string;
+  /** The configured encodings at the time, so a differently-configured pass cannot hit. */
+  under: string;
+  /**
+   * Suffixes the pass wrote. **Empty is a value, not a missing entry:** it records that these
+   * bytes yield no variant — a conclusion reached only by encoding at full quality, which is
+   * the most expensive thing the walk does and the one worth never repeating.
+   */
+  wrote: readonly string[];
+}
+
 /**
- * Source bytes this process has already reconciled, by absolute path. Keyed on **content**,
- * never on the path alone: a later environment may rewrite a file an earlier pass handled,
- * and a path-keyed memo would skip it and leave the earlier bytes' variants in place.
+ * What this process has already reconciled, by absolute path. Keyed on **content**, never on
+ * the path alone: a later environment may rewrite a file an earlier pass handled, and a
+ * path-keyed memo would skip it and leave the earlier bytes' variants in place.
  */
-const reconciled = new Map<string, string>();
+const reconciled = new Map<string, Reconciled>();
 
 /** Whether every configured variant decodes to exactly the identity beside it. A missing
  *  variant, a decode failure, or any difference means reconcile. */
@@ -173,9 +185,9 @@ async function decodesToSource(filePath: string, source: Buffer, resolved: Resol
 /** The memo says what we wrote, not what is on disk — so presence is still checked. Anything
  *  that removed a variant since (a cleaned output directory, a rebuild in the same process)
  *  falls through and re-emits. */
-async function variantsPresent(filePath: string, resolved: ResolvedPrecompress): Promise<boolean> {
-  for (const encoding of resolved.encodings) {
-    const there = await stat(filePath + CODECS[encoding].ext).then(
+async function allPresent(filePath: string, suffixes: readonly string[]): Promise<boolean> {
+  for (const suffix of suffixes) {
+    const there = await stat(filePath + suffix).then(
       () => true,
       () => false,
     );
@@ -185,23 +197,36 @@ async function variantsPresent(filePath: string, resolved: ResolvedPrecompress):
 }
 
 /**
- * Whether this file's variants are already correct. A memo hit costs one hash and one `stat`
- * per encoding; a miss falls through to decoding every variant, which is ~7x dearer per file
- * and is what every extra environment would otherwise pay for the whole asset set.
+ * Whether this file's variants are already correct. A memo hit costs one hash and a `stat`
+ * for each variant the pass wrote — none at all for bytes that yield no variant; a miss falls
+ * through to decoding every variant, which is what every extra environment would otherwise pay
+ * for the whole asset set.
  */
 async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
   const digest = createHash("sha256").update(source).digest("hex");
-  if (reconciled.get(filePath) === digest) return variantsPresent(filePath, resolved);
+  const memo = reconciled.get(filePath);
+  if (memo?.digest === digest && memo.under === resolved.encodings.join()) return allPresent(filePath, memo.wrote);
 
   const current = await decodesToSource(filePath, source, resolved);
-  if (current) reconciled.set(filePath, digest);
+  // Every configured variant just decoded to the source, so all of them are on disk.
+  if (current)
+    remember(
+      filePath,
+      source,
+      resolved,
+      resolved.encodings.map((e) => CODECS[e].ext),
+    );
   return current;
 }
 
-/** Record that these exact bytes were reconciled, so later passes skip on a hash instead of
- *  a decode. */
-function remember(filePath: string, source: Buffer): void {
-  reconciled.set(filePath, createHash("sha256").update(source).digest("hex"));
+/** Record what these exact bytes reconciled to, so later passes skip on a hash instead of a
+ *  decode — or, when nothing was written, without touching the disk at all. */
+function remember(filePath: string, source: Buffer, resolved: ResolvedPrecompress, wrote: readonly string[]): void {
+  reconciled.set(filePath, {
+    digest: createHash("sha256").update(source).digest("hex"),
+    under: resolved.encodings.join(),
+    wrote,
+  });
 }
 
 /** Whether the variants beside this file are ours to write and remove. */
@@ -210,15 +235,15 @@ function ownsVariantsFor(filePath: string, relPath: string, context: Precompress
   return !context.passThrough?.has(relPath);
 }
 
-/** Write the variants this build owes and remove the ones it does not, returning how many
- *  were written. */
+/** Write the variants this build owes and remove the ones it does not, returning the suffixes
+ *  written. */
 async function reconcile(
   filePath: string,
   source: Buffer,
   eligible: boolean,
   resolved: ResolvedPrecompress,
-): Promise<number> {
-  let written = 0;
+): Promise<string[]> {
+  const wrote: string[] = [];
   for (const encoding of resolved.encodings) {
     const codec = CODECS[encoding];
     const variantPath = filePath + codec.ext;
@@ -226,7 +251,7 @@ async function reconcile(
       const encoded = await codec.encode(source);
       if (notLarger(source, encoded)) {
         await writeFile(variantPath, encoded);
-        written++;
+        wrote.push(codec.ext);
         continue;
       }
     }
@@ -234,7 +259,7 @@ async function reconcile(
     // fails is not swallowed: it stops the build.
     await rm(variantPath, { force: true });
   }
-  return written;
+  return wrote;
 }
 
 async function processFile(
@@ -253,9 +278,9 @@ async function processFile(
   // lower threshold would survive.
   if (eligible && (await isCurrent(filePath, source, resolved))) return 0;
 
-  const written = await reconcile(filePath, source, eligible, resolved);
-  if (eligible) remember(filePath, source);
-  return written;
+  const wrote = await reconcile(filePath, source, eligible, resolved);
+  if (eligible) remember(filePath, source, resolved, wrote);
+  return wrote.length;
 }
 
 /**

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { extname, join, posix, sep } from "node:path";
 import { promisify } from "node:util";
 import { brotliCompress, constants, gzip } from "node:zlib";
@@ -102,33 +102,18 @@ async function processFile(
   const eligible = source.length >= resolved.threshold;
   // Eligibility first: an ineligible file must reach `reconcile`, or a variant left by a
   // lower threshold would survive.
-  if (eligible && (await isCurrent(filePath, source, resolved))) return 0;
+  const record = eligible ? recordOf(source, resolved) : undefined;
+  if (record !== undefined && reconciled.get(filePath) === record) return 0;
 
-  const wrote = await reconcile(filePath, source, eligible, resolved);
-  if (eligible) remember(filePath, source, resolved, wrote);
-  return wrote.length;
+  const written = await reconcile(filePath, source, eligible, resolved);
+  if (record !== undefined) reconciled.set(filePath, record);
+  return written;
 }
 
 /** Whether the variants beside this file are ours to write and remove. */
 function ownsVariantsFor(filePath: string, relPath: string, context: PrecompressContext): boolean {
   if (!NEGOTIABLE.has(extname(filePath).toLowerCase())) return false;
   return !context.passThrough?.has(relPath);
-}
-
-/**
- * Whether this file is already reconciled: the source hashes to the record this process kept,
- * and the suffixes that pass wrote are still on disk. Nothing on disk is read.
- */
-async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
-  const key = lookupKey(source, resolved);
-  const record = reconciled.get(filePath);
-  if (record === undefined || !record.startsWith(key)) return false;
-  return stillWritten(filePath, record.slice(key.length));
-}
-
-/** Record what this pass reconciled, so later passes settle it with a hash. */
-function remember(filePath: string, source: Buffer, resolved: ResolvedPrecompress, wrote: readonly string[]): void {
-  reconciled.set(filePath, recordOf(source, resolved, wrote));
 }
 
 /** Write the variants this build owes and remove the ones it does not, returning how many were
@@ -138,8 +123,8 @@ async function reconcile(
   source: Buffer,
   eligible: boolean,
   resolved: ResolvedPrecompress,
-): Promise<string[]> {
-  const wrote: string[] = [];
+): Promise<number> {
+  let written = 0;
   for (const encoding of resolved.encodings) {
     const codec = CODECS[encoding];
     const variantPath = filePath + codec.ext;
@@ -147,7 +132,7 @@ async function reconcile(
       const encoded = await codec.encode(source);
       if (notLarger(source, encoded)) {
         await writeFile(variantPath, encoded);
-        wrote.push(codec.ext);
+        written++;
         continue;
       }
     }
@@ -155,7 +140,7 @@ async function reconcile(
     // fails is not swallowed: it stops the build.
     await rm(variantPath, { force: true });
   }
-  return wrote;
+  return written;
 }
 
 /** Every file under `dir`, as absolute paths. Nothing is filtered here — extensions are
@@ -204,33 +189,10 @@ function digestOf(bytes: Buffer): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
-/** What a pass records for a file: the source bytes it reconciled, the configuration it
- *  reconciled them for, and the suffixes it wrote. A differently-configured pass owes different
- *  variants, so it must miss. */
-function recordOf(source: Buffer, resolved: ResolvedPrecompress, wrote: readonly string[]): string {
-  return `${digestOf(source)}\0${resolved.encodings.join()}\0${wrote.join()}`;
-}
-
-/** The prefix a later pass can compute without knowing what was written. */
-function lookupKey(source: Buffer, resolved: ResolvedPrecompress): string {
-  return `${digestOf(source)}\0${resolved.encodings.join()}\0`;
-}
-
-/** Whether the suffixes a pass wrote are still on disk. Empty is a value: a file that earned
- *  no variant has nothing to check, so it skips without touching the disk. Only ENOENT counts
- *  as absent — reading any other error as "gone" would re-encode on a broken filesystem. */
-async function stillWritten(filePath: string, suffixes: string): Promise<boolean> {
-  for (const suffix of suffixes ? suffixes.split(",") : []) {
-    const there = await stat(filePath + suffix).then(
-      () => true,
-      (error: NodeJS.ErrnoException) => {
-        if (error.code === "ENOENT") return false;
-        throw error;
-      },
-    );
-    if (!there) return false;
-  }
-  return true;
+/** What a pass records for a file: the source bytes it reconciled, under the configuration it
+ *  reconciled them for. A differently-configured pass owes different variants, so it must miss. */
+function recordOf(source: Buffer, resolved: ResolvedPrecompress): string {
+  return `${digestOf(source)}\0${resolved.encodings.join()}`;
 }
 
 const brotliAsync = promisify(brotliCompress);
@@ -275,8 +237,14 @@ const NEGOTIABLE = new Set([".css", ".htm", ".html", ".js", ".json", ".mjs", ".s
 const CONCURRENCY = 4;
 
 /**
- * What this process has already reconciled, by absolute path. Keyed on **content**, never on
+ * What this build has already reconciled, by absolute path. Keyed on **content**, never on
  * the path alone: a later environment may rewrite a file an earlier pass handled, and a
  * path-keyed memo would skip it and leave the earlier bytes' variants in place.
  */
 const reconciled = new Map<string, string>();
+
+/** Vite empties the output directory before the next build, so a record that outlived one would
+ *  describe files that are gone. Cleared once per build, before any environment pass. */
+export function forgetReconciled(): void {
+  reconciled.clear();
+}

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -4,41 +4,7 @@ import { extname, join, posix, sep } from "node:path";
 import { promisify } from "node:util";
 import { brotliCompress, brotliDecompress, constants, gunzip, gzip } from "node:zlib";
 
-const brotliAsync = promisify(brotliCompress);
-const gzipAsync = promisify(gzip);
-const brotliDecompressAsync = promisify(brotliDecompress);
-const gunzipAsync = promisify(gunzip);
-
 export type PrecompressEncoding = "br" | "gzip";
-
-interface Codec {
-  /** Suffix of the variant file, and the value srvx is handed to look one up. */
-  ext: string;
-  encode: (source: Buffer) => Promise<Buffer>;
-  decode: (bytes: Buffer) => Promise<Buffer>;
-}
-
-/** Everything one encoding needs — suffix, encode, decode — in one entry, checked against
- *  `PrecompressEncoding` so the table and the union cannot disagree. */
-const CODECS = {
-  br: {
-    ext: ".br",
-    encode: (source) =>
-      brotliAsync(source, {
-        params: {
-          // Build time, once — the whole point of not paying it per request.
-          [constants.BROTLI_PARAM_QUALITY]: constants.BROTLI_MAX_QUALITY,
-          [constants.BROTLI_PARAM_SIZE_HINT]: source.length,
-        },
-      }),
-    decode: (bytes) => brotliDecompressAsync(bytes),
-  },
-  gzip: {
-    ext: ".gz",
-    encode: (source) => gzipAsync(source, { level: constants.Z_BEST_COMPRESSION }),
-    decode: (bytes) => gunzipAsync(bytes),
-  },
-} satisfies Record<PrecompressEncoding, Codec>;
 
 export interface PrecompressOptions {
   /**
@@ -62,16 +28,37 @@ export interface ResolvedPrecompress {
   threshold: number;
 }
 
-/**
- * Extensions srvx negotiates an encoding for: the entries of its `COMMON_MIME_TYPES`
- * whose type passes its `isCompressible()`. A variant outside this set can never be
- * served, so emitting one would be dead bytes on disk.
- */
-const NEGOTIABLE = new Set([".css", ".htm", ".html", ".js", ".json", ".mjs", ".svg", ".txt", ".wasm", ".xml"]);
+export interface PrecompressContext {
+  /** Paths under `publicDir`, relative to the served directory with `/` separators. They
+   *  are re-copied from source every build, so their variants are the user's. */
+  passThrough?: ReadonlySet<string>;
+}
 
-// `node:zlib`'s async calls run on libuv's threadpool, which defaults to 4 workers;
-// queueing past it buys no parallelism while multiplying peak memory.
-const CONCURRENCY = 4;
+/**
+ * Emit `.br`/`.gz` variants beside the eligible files under `dir`, and retire the
+ * current encodings' variants beside the ones that got none.
+ */
+export async function precompressDir(
+  dir: string,
+  resolved: ResolvedPrecompress,
+  context: PrecompressContext = {},
+): Promise<{ written: number }> {
+  const files = await collectFiles(dir);
+  const toRelative = relativeTo(dir);
+
+  // One cursor shared by every worker, so each file is handed out exactly once.
+  const queue = files[Symbol.iterator]();
+  let written = 0;
+  const worker = async (): Promise<void> => {
+    for (const filePath of queue) {
+      const count = await processFile(filePath, toRelative(filePath), resolved, context);
+      written += count;
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, files.length) }, worker));
+
+  return { written };
+}
 
 /** `undefined` when precompression is off — the single off-switch. */
 export function resolvePrecompress(
@@ -95,99 +82,78 @@ export function encodingsMap(resolved: ResolvedPrecompress): Record<string, stri
   return Object.fromEntries(resolved.encodings.map((name) => [name, CODECS[name].ext]));
 }
 
-/** A file can vanish between the walk listing it and this read. Only ENOENT is benign —
- *  reading any other error as "absent" would leave the variants beside it in place. */
-async function readIfPresent(path: string): Promise<Buffer | null> {
-  try {
-    return await readFile(path);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-    throw error;
-  }
-}
-
-/** srvx compares no sizes: whatever variant is on disk is what it serves. */
-function notLarger(source: Buffer, variant: Buffer): boolean {
-  return variant.length <= source.length;
-}
-
-/** Every file under `dir`, as absolute paths. Nothing is filtered here — extensions are
- *  a per-file decision, never a traversal filter. */
-async function collectFiles(dir: string): Promise<string[]> {
-  const found: string[] = [];
-  const walk = async (current: string): Promise<void> => {
-    const entries = await readdir(current, { withFileTypes: true }).catch((error: NodeJS.ErrnoException) => {
-      // A directory can vanish mid-walk; anything else means the listing is not trustworthy.
-      if (error.code === "ENOENT") return [];
-      throw error;
-    });
-    for (const entry of entries) {
-      const full = join(current, entry.name);
-      if (entry.isDirectory()) await walk(full);
-      else if (entry.isFile()) found.push(full);
-    }
-  };
-  await walk(dir);
-  return found;
-}
-
-/** Maps absolute paths under `dir` to `dir`-relative, `/`-separated ones. */
-function relativeTo(dir: string): (file: string) => string {
-  const prefix = dir.endsWith(sep) ? dir.length : dir.length + 1;
-  return (file) => file.slice(prefix).split(sep).join(posix.sep);
-}
-
 /** Paths under `dir`, relative to it and with `/` separators. */
 export async function collectRelativeFiles(dir: string): Promise<Set<string>> {
   const files = await collectFiles(dir);
   return new Set(files.map(relativeTo(dir)));
 }
 
-export interface PrecompressContext {
-  /** Paths under `publicDir`, relative to the served directory with `/` separators. They
-   *  are re-copied from source every build, so their variants are the user's. */
-  passThrough?: ReadonlySet<string>;
+async function processFile(
+  filePath: string,
+  relPath: string,
+  resolved: ResolvedPrecompress,
+  context: PrecompressContext,
+): Promise<number> {
+  if (!ownsVariantsFor(filePath, relPath, context)) return 0;
+
+  const source = await readIfPresent(filePath);
+  if (!source) return 0;
+
+  const eligible = source.length >= resolved.threshold;
+  // Eligibility first: an ineligible file must reach `reconcile`, or a variant left by a
+  // lower threshold would survive.
+  if (eligible && (await isCurrent(filePath, source, resolved))) return 0;
+
+  const wrote = await reconcile(filePath, source, eligible, resolved);
+  if (eligible) remember(filePath, source, resolved, wrote);
+  return wrote.size;
 }
 
-interface Reconciled {
-  /** The source bytes. Compared first, so a changed file is a miss without reading a variant. */
-  digest: string;
-  /**
-   * One digest over the configured encodings and what each suffix held. A planted or altered
-   * variant misses because its own digest enters the fold. The empty marker buys the widening
-   * case: without a term for a suffix nothing was written to, a pass configured with one
-   * encoding and a pass configured with two that wrote only the first fold identically.
-   */
-  variants: string;
-}
-
-function digestOf(bytes: Buffer): string {
-  return createHash("sha256").update(bytes).digest("hex");
+/** Whether the variants beside this file are ours to write and remove. */
+function ownsVariantsFor(filePath: string, relPath: string, context: PrecompressContext): boolean {
+  if (!NEGOTIABLE.has(extname(filePath).toLowerCase())) return false;
+  return !context.passThrough?.has(relPath);
 }
 
 /**
- * Fold the configured encodings and each suffix's digest into one value. `held` returns the
- * digest of what a suffix holds, or `undefined` for nothing — and a digest is never empty, so
- * the empty marker cannot collide with one.
+ * Whether this file's variants are already correct. A memo hit reads each variant and hashes
+ * it; a miss decodes them instead. Hashing the stored representation is far cheaper than
+ * decompressing it, which is where the saving comes from — not from checking less.
  */
-function foldVariants(resolved: ResolvedPrecompress, held: (suffix: string) => string | undefined): string {
-  const composite = createHash("sha256");
+async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
+  const digest = digestOf(source);
+  const memo = reconciled.get(filePath);
+  // Source digest first: a changed file misses without reading a single variant.
+  if (memo?.digest === digest && (await matchesRecord(filePath, resolved, memo.variants))) return true;
+
+  // For a directory that was already correct, this is the only place an entry is ever written:
+  // returning true here makes `processFile` return before reaching its own `remember`. Delete
+  // it and that state re-decodes on every later pass, having no other way to be recorded.
+  const verified = await decodesToSource(filePath, source, resolved);
+  if (verified) remember(filePath, source, resolved, verified);
+  return verified !== null;
+}
+
+/**
+ * Whether every configured suffix still matches what the recorded pass left: the same bytes
+ * where one was written, and nothing at all where one was not.
+ *
+ * Both halves are load-bearing. srvx serves an adjacent variant without comparing it to the
+ * identity, so a variant that is present-but-altered, or present where reconciliation removed
+ * one, is wrong bytes on a live URL. A directory entry existing is not evidence it is ours.
+ */
+async function matchesRecord(filePath: string, resolved: ResolvedPrecompress, expected: string): Promise<boolean> {
+  const onDisk = new Map<string, string>();
   for (const encoding of resolved.encodings) {
-    composite
-      .update(encoding)
-      .update("\0")
-      .update(held(CODECS[encoding].ext) ?? "")
-      .update("\0");
+    const suffix = CODECS[encoding].ext;
+    // `readIfPresent`, not a swallowing catch: only ENOENT may count as absent. Reading
+    // EACCES or EIO as "nothing there" would make the absence proof vacuous on exactly the
+    // machines where it matters, and pass every test a healthy filesystem can run.
+    const bytes = await readIfPresent(filePath + suffix);
+    if (bytes) onDisk.set(suffix, digestOf(bytes));
   }
-  return composite.digest("hex");
+  return foldVariants(resolved, (suffix) => onDisk.get(suffix)) === expected;
 }
-
-/**
- * What this process has already reconciled, by absolute path. Keyed on **content**, never on
- * the path alone: a later environment may rewrite a file an earlier pass handled, and a
- * path-keyed memo would skip it and leave the earlier bytes' variants in place.
- */
-const reconciled = new Map<string, Reconciled>();
 
 /**
  * The digests of every configured variant, when each one decodes to exactly the identity
@@ -213,46 +179,6 @@ async function decodesToSource(
   return digests;
 }
 
-/**
- * Whether every configured suffix still matches what the recorded pass left: the same bytes
- * where one was written, and nothing at all where one was not.
- *
- * Both halves are load-bearing. srvx serves an adjacent variant without comparing it to the
- * identity, so a variant that is present-but-altered, or present where reconciliation removed
- * one, is wrong bytes on a live URL. A directory entry existing is not evidence it is ours.
- */
-async function matchesRecord(filePath: string, resolved: ResolvedPrecompress, expected: string): Promise<boolean> {
-  const onDisk = new Map<string, string>();
-  for (const encoding of resolved.encodings) {
-    const suffix = CODECS[encoding].ext;
-    // `readIfPresent`, not a swallowing catch: only ENOENT may count as absent. Reading
-    // EACCES or EIO as "nothing there" would make the absence proof vacuous on exactly the
-    // machines where it matters, and pass every test a healthy filesystem can run.
-    const bytes = await readIfPresent(filePath + suffix);
-    if (bytes) onDisk.set(suffix, digestOf(bytes));
-  }
-  return foldVariants(resolved, (suffix) => onDisk.get(suffix)) === expected;
-}
-
-/**
- * Whether this file's variants are already correct. A memo hit reads each variant and hashes
- * it; a miss decodes them instead. Hashing the stored representation is far cheaper than
- * decompressing it, which is where the saving comes from — not from checking less.
- */
-async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
-  const digest = digestOf(source);
-  const memo = reconciled.get(filePath);
-  // Source digest first: a changed file misses without reading a single variant.
-  if (memo?.digest === digest && (await matchesRecord(filePath, resolved, memo.variants))) return true;
-
-  // For a directory that was already correct, this is the only place an entry is ever written:
-  // returning true here makes `processFile` return before reaching its own `remember`. Delete
-  // it and that state re-decodes on every later pass, having no other way to be recorded.
-  const verified = await decodesToSource(filePath, source, resolved);
-  if (verified) remember(filePath, source, resolved, verified);
-  return verified !== null;
-}
-
 /** Record what these exact bytes reconciled to, so later passes verify by hash rather than by
  *  decode. */
 function remember(
@@ -265,12 +191,6 @@ function remember(
     digest: digestOf(source),
     variants: foldVariants(resolved, (suffix) => wrote.get(suffix)),
   });
-}
-
-/** Whether the variants beside this file are ours to write and remove. */
-function ownsVariantsFor(filePath: string, relPath: string, context: PrecompressContext): boolean {
-  if (!NEGOTIABLE.has(extname(filePath).toLowerCase())) return false;
-  return !context.passThrough?.has(relPath);
 }
 
 /** Write the variants this build owes and remove the ones it does not, returning the suffixes
@@ -302,49 +222,132 @@ async function reconcile(
   return wrote;
 }
 
-async function processFile(
-  filePath: string,
-  relPath: string,
-  resolved: ResolvedPrecompress,
-  context: PrecompressContext,
-): Promise<number> {
-  if (!ownsVariantsFor(filePath, relPath, context)) return 0;
+/** Every file under `dir`, as absolute paths. Nothing is filtered here — extensions are
+ *  a per-file decision, never a traversal filter. */
+async function collectFiles(dir: string): Promise<string[]> {
+  const found: string[] = [];
+  const walk = async (current: string): Promise<void> => {
+    const entries = await readdir(current, { withFileTypes: true }).catch((error: NodeJS.ErrnoException) => {
+      // A directory can vanish mid-walk; anything else means the listing is not trustworthy.
+      if (error.code === "ENOENT") return [];
+      throw error;
+    });
+    for (const entry of entries) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) await walk(full);
+      else if (entry.isFile()) found.push(full);
+    }
+  };
+  await walk(dir);
+  return found;
+}
 
-  const source = await readIfPresent(filePath);
-  if (!source) return 0;
+/** Maps absolute paths under `dir` to `dir`-relative, `/`-separated ones. */
+function relativeTo(dir: string): (file: string) => string {
+  const prefix = dir.endsWith(sep) ? dir.length : dir.length + 1;
+  return (file) => file.slice(prefix).split(sep).join(posix.sep);
+}
 
-  const eligible = source.length >= resolved.threshold;
-  // Eligibility first: an ineligible file must reach `reconcile`, or a variant left by a
-  // lower threshold would survive.
-  if (eligible && (await isCurrent(filePath, source, resolved))) return 0;
+/** A file can vanish between the walk listing it and this read. Only ENOENT is benign —
+ *  reading any other error as "absent" would leave the variants beside it in place. */
+async function readIfPresent(path: string): Promise<Buffer | null> {
+  try {
+    return await readFile(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
 
-  const wrote = await reconcile(filePath, source, eligible, resolved);
-  if (eligible) remember(filePath, source, resolved, wrote);
-  return wrote.size;
+/** srvx compares no sizes: whatever variant is on disk is what it serves. */
+function notLarger(source: Buffer, variant: Buffer): boolean {
+  return variant.length <= source.length;
+}
+
+function digestOf(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
 }
 
 /**
- * Emit `.br`/`.gz` variants beside the eligible files under `dir`, and retire the
- * current encodings' variants beside the ones that got none.
+ * Fold the configured encodings and each suffix's digest into one value. `held` returns the
+ * digest of what a suffix holds, or `undefined` for nothing — and a digest is never empty, so
+ * the empty marker cannot collide with one.
  */
-export async function precompressDir(
-  dir: string,
-  resolved: ResolvedPrecompress,
-  context: PrecompressContext = {},
-): Promise<{ written: number }> {
-  const files = await collectFiles(dir);
-  const toRelative = relativeTo(dir);
-
-  // One cursor shared by every worker, so each file is handed out exactly once.
-  const queue = files[Symbol.iterator]();
-  let written = 0;
-  const worker = async (): Promise<void> => {
-    for (const filePath of queue) {
-      const count = await processFile(filePath, toRelative(filePath), resolved, context);
-      written += count;
-    }
-  };
-  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, files.length) }, worker));
-
-  return { written };
+function foldVariants(resolved: ResolvedPrecompress, held: (suffix: string) => string | undefined): string {
+  const composite = createHash("sha256");
+  for (const encoding of resolved.encodings) {
+    composite
+      .update(encoding)
+      .update("\0")
+      .update(held(CODECS[encoding].ext) ?? "")
+      .update("\0");
+  }
+  return composite.digest("hex");
 }
+
+const brotliAsync = promisify(brotliCompress);
+
+const gzipAsync = promisify(gzip);
+
+const brotliDecompressAsync = promisify(brotliDecompress);
+
+const gunzipAsync = promisify(gunzip);
+
+interface Codec {
+  /** Suffix of the variant file, and the value srvx is handed to look one up. */
+  ext: string;
+  encode: (source: Buffer) => Promise<Buffer>;
+  decode: (bytes: Buffer) => Promise<Buffer>;
+}
+
+/** Everything one encoding needs — suffix, encode, decode — in one entry, checked against
+ *  `PrecompressEncoding` so the table and the union cannot disagree. */
+const CODECS = {
+  br: {
+    ext: ".br",
+    encode: (source) =>
+      brotliAsync(source, {
+        params: {
+          // Build time, once — the whole point of not paying it per request.
+          [constants.BROTLI_PARAM_QUALITY]: constants.BROTLI_MAX_QUALITY,
+          [constants.BROTLI_PARAM_SIZE_HINT]: source.length,
+        },
+      }),
+    decode: (bytes) => brotliDecompressAsync(bytes),
+  },
+  gzip: {
+    ext: ".gz",
+    encode: (source) => gzipAsync(source, { level: constants.Z_BEST_COMPRESSION }),
+    decode: (bytes) => gunzipAsync(bytes),
+  },
+} satisfies Record<PrecompressEncoding, Codec>;
+
+/**
+ * Extensions srvx negotiates an encoding for: the entries of its `COMMON_MIME_TYPES`
+ * whose type passes its `isCompressible()`. A variant outside this set can never be
+ * served, so emitting one would be dead bytes on disk.
+ */
+const NEGOTIABLE = new Set([".css", ".htm", ".html", ".js", ".json", ".mjs", ".svg", ".txt", ".wasm", ".xml"]);
+
+// `node:zlib`'s async calls run on libuv's threadpool, which defaults to 4 workers;
+// queueing past it buys no parallelism while multiplying peak memory.
+const CONCURRENCY = 4;
+
+interface Reconciled {
+  /** The source bytes. Compared first, so a changed file is a miss without reading a variant. */
+  digest: string;
+  /**
+   * One digest over the configured encodings and what each suffix held. A planted or altered
+   * variant misses because its own digest enters the fold. The empty marker buys the widening
+   * case: without a term for a suffix nothing was written to, a pass configured with one
+   * encoding and a pass configured with two that wrote only the first fold identically.
+   */
+  variants: string;
+}
+
+/**
+ * What this process has already reconciled, by absolute path. Keyed on **content**, never on
+ * the path alone: a later environment may rewrite a file an earlier pass handled, and a
+ * path-keyed memo would skip it and leave the earlier bytes' variants in place.
+ */
+const reconciled = new Map<string, Reconciled>();

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -243,8 +243,8 @@ const CONCURRENCY = 4;
  */
 const reconciled = new Map<string, string>();
 
-/** Vite empties the output directory before the next build, so a record that outlived one would
- *  describe files that are gone. Cleared once per build, before any environment pass. */
+/** A later build may empty the output directory, so a record that outlived one would describe
+ *  files that are gone. Cleared during config resolution, before any environment `buildStart`. */
 export function forgetReconciled(): void {
   reconciled.clear();
 }

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -156,23 +156,20 @@ async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPre
   return true;
 }
 
-async function processFile(
+/** Whether the variants beside this file are ours to write and remove. */
+function ownsVariantsFor(filePath: string, relPath: string, context: PrecompressContext): boolean {
+  if (!NEGOTIABLE.has(extname(filePath).toLowerCase())) return false;
+  return !context.passThrough?.has(relPath);
+}
+
+/** Write the variants this build owes and remove the ones it does not, returning how many
+ *  were written. */
+async function reconcile(
   filePath: string,
-  relPath: string,
+  source: Buffer,
+  eligible: boolean,
   resolved: ResolvedPrecompress,
-  context: PrecompressContext,
 ): Promise<number> {
-  if (!NEGOTIABLE.has(extname(filePath).toLowerCase())) return 0;
-  if (context.passThrough?.has(relPath)) return 0;
-
-  const source = await readIfPresent(filePath);
-  if (!source) return 0;
-
-  const eligible = source.length >= resolved.threshold;
-  // Eligibility first: an ineligible file must reach the reconcile loop, or a variant left
-  // by a lower threshold would survive.
-  if (eligible && (await isCurrent(filePath, source, resolved))) return 0;
-
   let written = 0;
   for (const encoding of resolved.encodings) {
     const codec = CODECS[encoding];
@@ -190,6 +187,25 @@ async function processFile(
     await rm(variantPath, { force: true });
   }
   return written;
+}
+
+async function processFile(
+  filePath: string,
+  relPath: string,
+  resolved: ResolvedPrecompress,
+  context: PrecompressContext,
+): Promise<number> {
+  if (!ownsVariantsFor(filePath, relPath, context)) return 0;
+
+  const source = await readIfPresent(filePath);
+  if (!source) return 0;
+
+  const eligible = source.length >= resolved.threshold;
+  // Eligibility first: an ineligible file must reach `reconcile`, or a variant left by a
+  // lower threshold would survive.
+  if (eligible && (await isCurrent(filePath, source, resolved))) return 0;
+
+  return reconcile(filePath, source, eligible, resolved);
 }
 
 /**

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -8,6 +8,8 @@ const gzipAsync = promisify(gzip);
 const brotliDecompressAsync = promisify(brotliDecompress);
 const gunzipAsync = promisify(gunzip);
 
+export type PrecompressEncoding = "br" | "gzip";
+
 interface Codec {
   /** Suffix of the variant file, and the value srvx is handed to look one up. */
   ext: string;
@@ -15,7 +17,8 @@ interface Codec {
   decode: (bytes: Buffer) => Promise<Buffer>;
 }
 
-/** One entry per encoding, so a new one is added in a single place. */
+/** Everything one encoding needs — suffix, encode, decode — in one entry, checked against
+ *  `PrecompressEncoding` so the table and the union cannot disagree. */
 const CODECS = {
   br: {
     ext: ".br",
@@ -34,9 +37,7 @@ const CODECS = {
     encode: (source) => gzipAsync(source, { level: constants.Z_BEST_COMPRESSION }),
     decode: (bytes) => gunzipAsync(bytes),
   },
-} satisfies Record<string, Codec>;
-
-export type PrecompressEncoding = keyof typeof CODECS;
+} satisfies Record<PrecompressEncoding, Codec>;
 
 export interface PrecompressOptions {
   /**

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -3,7 +3,40 @@ import { extname, join, posix, sep } from "node:path";
 import { promisify } from "node:util";
 import { brotliCompress, brotliDecompress, constants, gunzip, gzip } from "node:zlib";
 
-export type PrecompressEncoding = "br" | "gzip";
+const brotliAsync = promisify(brotliCompress);
+const gzipAsync = promisify(gzip);
+const brotliDecompressAsync = promisify(brotliDecompress);
+const gunzipAsync = promisify(gunzip);
+
+interface Codec {
+  /** Suffix of the variant file, and the value srvx is handed to look one up. */
+  ext: string;
+  encode: (source: Buffer) => Promise<Buffer>;
+  decode: (bytes: Buffer) => Promise<Buffer>;
+}
+
+/** One entry per encoding, so a new one is added in a single place. */
+const CODECS = {
+  br: {
+    ext: ".br",
+    encode: (source) =>
+      brotliAsync(source, {
+        params: {
+          // Build time, once — the whole point of not paying it per request.
+          [constants.BROTLI_PARAM_QUALITY]: constants.BROTLI_MAX_QUALITY,
+          [constants.BROTLI_PARAM_SIZE_HINT]: source.length,
+        },
+      }),
+    decode: (bytes) => brotliDecompressAsync(bytes),
+  },
+  gzip: {
+    ext: ".gz",
+    encode: (source) => gzipAsync(source, { level: constants.Z_BEST_COMPRESSION }),
+    decode: (bytes) => gunzipAsync(bytes),
+  },
+} satisfies Record<string, Codec>;
+
+export type PrecompressEncoding = keyof typeof CODECS;
 
 export interface PrecompressOptions {
   /**
@@ -34,16 +67,9 @@ export interface ResolvedPrecompress {
  */
 const NEGOTIABLE = new Set([".css", ".htm", ".html", ".js", ".json", ".mjs", ".svg", ".txt", ".wasm", ".xml"]);
 
-const VARIANT_EXT: Record<PrecompressEncoding, string> = { br: ".br", gzip: ".gz" };
-
 // `node:zlib`'s async calls run on libuv's threadpool, which defaults to 4 workers;
 // queueing past it buys no parallelism while multiplying peak memory.
 const CONCURRENCY = 4;
-
-const brotliAsync = promisify(brotliCompress);
-const gzipAsync = promisify(gzip);
-const brotliDecompressAsync = promisify(brotliDecompress);
-const gunzipAsync = promisify(gunzip);
 
 /** `undefined` when precompression is off — the single off-switch. */
 export function resolvePrecompress(
@@ -64,23 +90,7 @@ export function resolvePrecompress(
  * beats the client's `Accept-Encoding` order, so it must follow `encodings`.
  */
 export function encodingsMap(resolved: ResolvedPrecompress): Record<string, string> {
-  return Object.fromEntries(resolved.encodings.map((name) => [name, VARIANT_EXT[name]]));
-}
-
-function encode(encoding: PrecompressEncoding, source: Buffer): Promise<Buffer> {
-  return encoding === "br"
-    ? brotliAsync(source, {
-        params: {
-          // Build time, once — the whole point of not paying it per request.
-          [constants.BROTLI_PARAM_QUALITY]: constants.BROTLI_MAX_QUALITY,
-          [constants.BROTLI_PARAM_SIZE_HINT]: source.length,
-        },
-      })
-    : gzipAsync(source, { level: constants.Z_BEST_COMPRESSION });
-}
-
-function decode(encoding: PrecompressEncoding, bytes: Buffer): Promise<Buffer> {
-  return encoding === "br" ? brotliDecompressAsync(bytes) : gunzipAsync(bytes);
+  return Object.fromEntries(resolved.encodings.map((name) => [name, CODECS[name].ext]));
 }
 
 /**
@@ -157,11 +167,12 @@ export interface PrecompressContext {
  */
 async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
   for (const encoding of resolved.encodings) {
+    const codec = CODECS[encoding];
     // Unreadable for any reason means not usable as-is; the reconcile path below then
     // deals with it and reports accurately if it cannot be removed.
-    const bytes = await readFile(filePath + VARIANT_EXT[encoding]).catch(() => null);
+    const bytes = await readFile(filePath + codec.ext).catch(() => null);
     if (!bytes || !notLarger(source, bytes)) return false;
-    const decoded = await decode(encoding, bytes).catch(() => null);
+    const decoded = await codec.decode(bytes).catch(() => null);
     if (!decoded || !decoded.equals(source)) return false;
   }
   return true;
@@ -188,9 +199,10 @@ async function processFile(
 
   let written = 0;
   for (const encoding of resolved.encodings) {
-    const variantPath = filePath + VARIANT_EXT[encoding];
+    const codec = CODECS[encoding];
+    const variantPath = filePath + codec.ext;
     if (eligible) {
-      const encoded = await encode(encoding, source);
+      const encoded = await codec.encode(source);
       if (notLarger(source, encoded)) {
         await writeFile(variantPath, encoded);
         written++;

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -96,12 +96,14 @@ async function readIfPresent(path: string): Promise<Buffer | null> {
 }
 
 /**
- * The one size rule. srvx compares nothing, so a variant that is not strictly smaller than
- * its identity would be served and would make the response bigger. Used both to accept a
- * fresh encode and to accept one already on disk, so the two cannot drift apart.
+ * The one size rule: a variant may not be larger than its identity. srvx compares nothing,
+ * so a larger variant would be served and would make the response bigger — that is the
+ * whole hazard, and an equal-sized variant does not cause it: the wire cost is identical
+ * and the request still avoids on-the-fly compression. Used both to accept a fresh encode
+ * and to accept one already on disk, so the two cannot drift apart.
  */
-function improves(source: Buffer, variant: Buffer): boolean {
-  return variant.length < source.length;
+function notLarger(source: Buffer, variant: Buffer): boolean {
+  return variant.length <= source.length;
 }
 
 /**
@@ -175,7 +177,7 @@ async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPre
     // Unreadable for any reason means not usable as-is; the reconcile path below then
     // deals with it and reports accurately if it cannot be removed.
     const bytes = await readFile(filePath + VARIANT_EXT[encoding]).catch(() => null);
-    if (!bytes || !improves(source, bytes)) return false;
+    if (!bytes || !notLarger(source, bytes)) return false;
     const decoded = await decode(encoding, bytes).catch(() => null);
     if (!decoded || !decoded.equals(source)) return false;
   }
@@ -207,14 +209,14 @@ async function processFile(
     let emitted = false;
     if (eligible) {
       const encoded = await encode(encoding, source);
-      if (improves(source, encoded)) {
+      if (notLarger(source, encoded)) {
         await writeFile(variantPath, encoded);
         emitted = true;
         written++;
       }
     }
-    // Rewritten on every build, never skipped — a skip is how a stale variant survives
-    // a content change.
+    // Every variant this build did not write is removed: a leftover beside a file whose
+    // contents or eligibility changed is how stale bytes get served.
     if (!emitted) await retire(variantPath);
   }
   return written;

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -243,8 +243,9 @@ const CONCURRENCY = 4;
  */
 const reconciled = new Map<string, string>();
 
-/** A later build may empty the output directory, so a record that outlived one would describe
- *  files that are gone. Cleared during config resolution, before any environment `buildStart`. */
+/** A later build may empty the output directory, so a record that outlived one would claim a
+ *  reconciliation whose variants are no longer there. Cleared during config resolution, before
+ *  any environment `buildStart`. */
 export function forgetReconciled(): void {
   reconciled.clear();
 }

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -116,9 +116,9 @@ function ownsVariantsFor(filePath: string, relPath: string, context: Precompress
 }
 
 /**
- * Whether this file is already reconciled. A later pass hashes the source and compares; it
- * verifies nothing on disk, because a build-time check cannot establish a property of a file
- * that is served long after the build exits.
+ * Whether this file is already reconciled. A later pass hashes the source and confirms the
+ * suffixes that pass wrote are still on disk; it does not read them, because whether a variant
+ * is still valid is a question about request time, not build time.
  */
 async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
   const key = lookupKey(source, resolved);

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -236,12 +236,31 @@ const NEGOTIABLE = new Set([".css", ".htm", ".html", ".js", ".json", ".mjs", ".s
 // queueing past it buys no parallelism while multiplying peak memory.
 const CONCURRENCY = 4;
 
+/** Identifies what a record means: the bytes it is keyed on, the variants a hit claims are on
+ *  disk, and the parameters those were encoded with. Copies of this module share a memo only when
+ *  their contracts match, so a copy that would write different variants cannot read these records.
+ *  Any change to what a reconciliation produces needs a new number. A hit is a comparison against
+ *  what this copy would record for the bytes in hand, so a number left unbumped can leave another
+ *  copy's compression parameters in place but not a variant whose source has changed. */
+const MEMO_CONTRACT = 1;
+
+const MEMO_KEY = Symbol.for(`@universal-deploy/node precompress memo v${MEMO_CONTRACT}`);
+
+/** A cast, not a `declare global`: augmenting `globalThis` would put this internal into the
+ *  published types. */
+const globalScope = globalThis as unknown as Record<symbol, Map<string, string> | undefined>;
+
 /**
  * What this build has already reconciled, by absolute path. Keyed on **content**, never on
  * the path alone: a later environment may rewrite a file an earlier pass handled, and a
  * path-keyed memo would skip it and leave the earlier bytes' variants in place.
+ *
+ * On `globalThis` rather than module scope, which is per module **instance**: dual resolution or
+ * two installed versions put more than one copy of this module in one process, and a per-copy
+ * memo would re-encode what another copy has already written.
  */
-const reconciled = new Map<string, string>();
+const reconciled = globalScope[MEMO_KEY] ?? new Map<string, string>();
+globalScope[MEMO_KEY] = reconciled;
 
 /** A later build may empty the output directory, so a record that outlived one would claim a
  *  reconciliation whose variants are no longer there. Cleared during config resolution, before

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -129,11 +129,16 @@ async function collectFiles(dir: string): Promise<string[]> {
   return found;
 }
 
+/** Maps absolute paths under `dir` to `dir`-relative, `/`-separated ones. */
+function relativeTo(dir: string): (file: string) => string {
+  const prefix = dir.endsWith(sep) ? dir.length : dir.length + 1;
+  return (file) => file.slice(prefix).split(sep).join(posix.sep);
+}
+
 /** Paths under `dir`, relative to it and with `/` separators. */
 export async function collectRelativeFiles(dir: string): Promise<Set<string>> {
   const files = await collectFiles(dir);
-  const prefix = dir.endsWith(sep) ? dir.length : dir.length + 1;
-  return new Set(files.map((file) => file.slice(prefix).split(sep).join(posix.sep)));
+  return new Set(files.map(relativeTo(dir)));
 }
 
 export interface PrecompressContext {
@@ -218,15 +223,14 @@ export async function precompressDir(
   context: PrecompressContext = {},
 ): Promise<{ written: number }> {
   const files = await collectFiles(dir);
-  const prefix = dir.endsWith(sep) ? dir.length : dir.length + 1;
+  const toRelative = relativeTo(dir);
 
-  let next = 0;
+  // One cursor shared by every worker, so each file is handed out exactly once.
+  const queue = files[Symbol.iterator]();
   let written = 0;
   const worker = async (): Promise<void> => {
-    while (next < files.length) {
-      const filePath = files[next++] as string;
-      const relPath = filePath.slice(prefix).split(sep).join(posix.sep);
-      const count = await processFile(filePath, relPath, resolved, context);
+    for (const filePath of queue) {
+      const count = await processFile(filePath, toRelative(filePath), resolved, context);
       written += count;
     }
   };

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -82,13 +82,39 @@ function decode(encoding: PrecompressEncoding, bytes: Buffer): Promise<Buffer> {
 }
 
 /**
+ * Read a file that may legitimately have vanished since the walk listed it. Only ENOENT is
+ * benign: a permission or I/O error means the tree is not what it appears to be, and
+ * treating that as "absent" would leave whatever variants are already beside it.
+ */
+async function readIfPresent(path: string): Promise<Buffer | null> {
+  try {
+    return await readFile(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+/**
+ * The one size rule. srvx compares nothing, so a variant that is not strictly smaller than
+ * its identity would be served and would make the response bigger. Used both to accept a
+ * fresh encode and to accept one already on disk, so the two cannot drift apart.
+ */
+function improves(source: Buffer, variant: Buffer): boolean {
+  return variant.length < source.length;
+}
+
+/**
  * Remove a variant this build did not write. A failed unlink is not an unlink, so an
  * unremovable variant is fatal rather than a warning: leaving it would let srvx serve
  * stale bytes as the current file's body.
  */
 async function retire(variantPath: string): Promise<void> {
   await rm(variantPath, { force: true }).catch(() => {});
-  const survivor = await stat(variantPath).catch(() => null);
+  const survivor = await stat(variantPath).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  });
   if (survivor) {
     throw new Error(
       `[ud:node:precompress] could not remove the stale variant ${variantPath}. ` +
@@ -102,7 +128,11 @@ async function retire(variantPath: string): Promise<void> {
 async function collectFiles(dir: string): Promise<string[]> {
   const found: string[] = [];
   const walk = async (current: string): Promise<void> => {
-    const entries = await readdir(current, { withFileTypes: true }).catch(() => []);
+    const entries = await readdir(current, { withFileTypes: true }).catch((error: NodeJS.ErrnoException) => {
+      // A directory can vanish mid-walk; anything else means the listing is not trustworthy.
+      if (error.code === "ENOENT") return [];
+      throw error;
+    });
     for (const entry of entries) {
       const full = join(current, entry.name);
       if (entry.isDirectory()) await walk(full);
@@ -142,8 +172,10 @@ export interface PrecompressContext {
  */
 async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
   for (const encoding of resolved.encodings) {
+    // Unreadable for any reason means not usable as-is; the reconcile path below then
+    // deals with it and reports accurately if it cannot be removed.
     const bytes = await readFile(filePath + VARIANT_EXT[encoding]).catch(() => null);
-    if (!bytes) return false;
+    if (!bytes || !improves(source, bytes)) return false;
     const decoded = await decode(encoding, bytes).catch(() => null);
     if (!decoded || !decoded.equals(source)) return false;
   }
@@ -159,14 +191,15 @@ async function processFile(
   if (!NEGOTIABLE.has(extname(filePath).toLowerCase())) return 0;
   if (context.passThrough?.has(relPath)) return 0;
 
-  const source = await readFile(filePath).catch(() => null);
+  const source = await readIfPresent(filePath);
   if (!source) return 0;
-  // Emission runs once per environment, so a multi-environment build walks the same
-  // directory more than once. Without this, every pass after the first would re-encode
-  // everything the earlier ones already did.
-  if (await isCurrent(filePath, source, resolved)) return 0;
 
   const eligible = source.length >= resolved.threshold;
+  // Emission runs once per environment, so a multi-environment build walks the same
+  // directory more than once; without this, every later pass re-encodes what the first
+  // already did. Eligibility is decided FIRST: a file this build would not compress must
+  // reach the reconcile path below, or a variant left by a lower threshold would survive.
+  if (eligible && (await isCurrent(filePath, source, resolved))) return 0;
 
   let written = 0;
   for (const encoding of resolved.encodings) {
@@ -174,9 +207,7 @@ async function processFile(
     let emitted = false;
     if (eligible) {
       const encoded = await encode(encoding, source);
-      // srvx compares nothing: a variant larger than its identity would be served and
-      // would make the response bigger.
-      if (encoded.length < source.length) {
+      if (improves(source, encoded)) {
         await writeFile(variantPath, encoded);
         emitted = true;
         written++;

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { extname, join, posix, sep } from "node:path";
 import { promisify } from "node:util";
 import { brotliCompress, brotliDecompress, constants, gunzip, gzip } from "node:zlib";
@@ -106,7 +106,7 @@ async function processFile(
 
   const wrote = await reconcile(filePath, source, eligible, resolved);
   if (eligible) remember(filePath, source, resolved, wrote);
-  return wrote.size;
+  return wrote.length;
 }
 
 /** Whether the variants beside this file are ours to write and remove. */
@@ -116,92 +116,56 @@ function ownsVariantsFor(filePath: string, relPath: string, context: Precompress
 }
 
 /**
- * Whether this file's variants are already correct. A memo hit reads each variant and hashes
- * it; a miss decodes them instead. Hashing the stored representation is far cheaper than
- * decompressing it, which is where the saving comes from — not from checking less.
+ * Whether this file is already reconciled. A later pass hashes the source and compares; it
+ * verifies nothing on disk, because a build-time check cannot establish a property of a file
+ * that is served long after the build exits.
  */
 async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
-  const digest = digestOf(source);
-  const memo = reconciled.get(filePath);
-  // Source digest first: a changed file misses without reading a single variant.
-  if (memo?.digest === digest && (await matchesRecord(filePath, resolved, memo.variants))) return true;
+  const key = lookupKey(source, resolved);
+  const record = reconciled.get(filePath);
+  if (record?.startsWith(key) && (await stillWritten(filePath, record.slice(key.length)))) return true;
 
   // For a directory that was already correct, this is the only place an entry is ever written:
   // returning true here makes `processFile` return before reaching its own `remember`. Delete
   // it and that state re-decodes on every later pass, having no other way to be recorded.
-  const verified = await decodesToSource(filePath, source, resolved);
-  if (verified) remember(filePath, source, resolved, verified);
-  return verified !== null;
+  if (!(await decodesToSource(filePath, source, resolved))) return false;
+  remember(
+    filePath,
+    source,
+    resolved,
+    resolved.encodings.map((e) => CODECS[e].ext),
+  );
+  return true;
 }
 
-/**
- * Whether every configured suffix still matches what the recorded pass left: the same bytes
- * where one was written, and nothing at all where one was not.
- *
- * Both halves are load-bearing. srvx serves an adjacent variant without comparing it to the
- * identity, so a variant that is present-but-altered, or present where reconciliation removed
- * one, is wrong bytes on a live URL. A directory entry existing is not evidence it is ours.
- */
-async function matchesRecord(filePath: string, resolved: ResolvedPrecompress, expected: string): Promise<boolean> {
-  const onDisk = new Map<string, string>();
-  for (const encoding of resolved.encodings) {
-    const suffix = CODECS[encoding].ext;
-    // `readIfPresent`, not a swallowing catch: only ENOENT may count as absent. Reading
-    // EACCES or EIO as "nothing there" would make the absence proof vacuous on exactly the
-    // machines where it matters, and pass every test a healthy filesystem can run.
-    const bytes = await readIfPresent(filePath + suffix);
-    if (bytes) onDisk.set(suffix, digestOf(bytes));
-  }
-  return foldVariants(resolved, (suffix) => onDisk.get(suffix)) === expected;
-}
-
-/**
- * The digests of every configured variant, when each one decodes to exactly the identity
- * beside it — `null` when any is missing, undecodable, or different. Returning the digests
- * rather than a flag lets a directory that was already correct be recorded without a second
- * read: the bytes were in hand anyway.
- */
-async function decodesToSource(
-  filePath: string,
-  source: Buffer,
-  resolved: ResolvedPrecompress,
-): Promise<Map<string, string> | null> {
-  const digests = new Map<string, string>();
+/** Whether every configured variant decodes to exactly the identity beside it. A missing
+ *  variant, a decode failure, or any difference means reconcile. */
+async function decodesToSource(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
   for (const encoding of resolved.encodings) {
     const codec = CODECS[encoding];
     // Unreadable for any reason means not usable as-is — the reconcile loop then deals with it.
     const bytes = await readFile(filePath + codec.ext).catch(() => null);
-    if (!bytes || !notLarger(source, bytes)) return null;
+    if (!bytes || !notLarger(source, bytes)) return false;
     const decoded = await codec.decode(bytes).catch(() => null);
-    if (!decoded || !decoded.equals(source)) return null;
-    digests.set(codec.ext, digestOf(bytes));
+    if (!decoded || !decoded.equals(source)) return false;
   }
-  return digests;
+  return true;
 }
 
-/** Record what these exact bytes reconciled to, so later passes verify by hash rather than by
- *  decode. */
-function remember(
-  filePath: string,
-  source: Buffer,
-  resolved: ResolvedPrecompress,
-  wrote: ReadonlyMap<string, string>,
-): void {
-  reconciled.set(filePath, {
-    digest: digestOf(source),
-    variants: foldVariants(resolved, (suffix) => wrote.get(suffix)),
-  });
+/** Record what this pass reconciled, so later passes skip on a hash instead of a decode. */
+function remember(filePath: string, source: Buffer, resolved: ResolvedPrecompress, wrote: readonly string[]): void {
+  reconciled.set(filePath, recordOf(source, resolved, wrote));
 }
 
-/** Write the variants this build owes and remove the ones it does not, returning the suffixes
+/** Write the variants this build owes and remove the ones it does not, returning how many were
  *  written. */
 async function reconcile(
   filePath: string,
   source: Buffer,
   eligible: boolean,
   resolved: ResolvedPrecompress,
-): Promise<Map<string, string>> {
-  const wrote = new Map<string, string>();
+): Promise<string[]> {
+  const wrote: string[] = [];
   for (const encoding of resolved.encodings) {
     const codec = CODECS[encoding];
     const variantPath = filePath + codec.ext;
@@ -209,9 +173,7 @@ async function reconcile(
       const encoded = await codec.encode(source);
       if (notLarger(source, encoded)) {
         await writeFile(variantPath, encoded);
-        // Digested here, while the buffer is already in hand — no second read — and it is
-        // what lets a later pass verify by hash instead of by decode.
-        wrote.set(codec.ext, digestOf(encoded));
+        wrote.push(codec.ext);
         continue;
       }
     }
@@ -268,21 +230,33 @@ function digestOf(bytes: Buffer): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
-/**
- * Fold the configured encodings and each suffix's digest into one value. `held` returns the
- * digest of what a suffix holds, or `undefined` for nothing — and a digest is never empty, so
- * the empty marker cannot collide with one.
- */
-function foldVariants(resolved: ResolvedPrecompress, held: (suffix: string) => string | undefined): string {
-  const composite = createHash("sha256");
-  for (const encoding of resolved.encodings) {
-    composite
-      .update(encoding)
-      .update("\0")
-      .update(held(CODECS[encoding].ext) ?? "")
-      .update("\0");
+/** What a pass records for a file: the source bytes it reconciled, the configuration it
+ *  reconciled them for, and the suffixes it wrote. A differently-configured pass owes different
+ *  variants, so it must miss. */
+function recordOf(source: Buffer, resolved: ResolvedPrecompress, wrote: readonly string[]): string {
+  return `${digestOf(source)}\0${resolved.encodings.join()}\0${wrote.join()}`;
+}
+
+/** The prefix a later pass can compute without knowing what was written. */
+function lookupKey(source: Buffer, resolved: ResolvedPrecompress): string {
+  return `${digestOf(source)}\0${resolved.encodings.join()}\0`;
+}
+
+/** Whether the suffixes a pass wrote are still on disk. Empty is a value: a file that earned
+ *  no variant has nothing to check, so it skips without touching the disk. Only ENOENT counts
+ *  as absent — reading any other error as "gone" would re-encode on a broken filesystem. */
+async function stillWritten(filePath: string, suffixes: string): Promise<boolean> {
+  for (const suffix of suffixes ? suffixes.split(",") : []) {
+    const there = await stat(filePath + suffix).then(
+      () => true,
+      (error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") return false;
+        throw error;
+      },
+    );
+    if (!there) return false;
   }
-  return composite.digest("hex");
+  return true;
 }
 
 const brotliAsync = promisify(brotliCompress);
@@ -333,21 +307,9 @@ const NEGOTIABLE = new Set([".css", ".htm", ".html", ".js", ".json", ".mjs", ".s
 // queueing past it buys no parallelism while multiplying peak memory.
 const CONCURRENCY = 4;
 
-interface Reconciled {
-  /** The source bytes. Compared first, so a changed file is a miss without reading a variant. */
-  digest: string;
-  /**
-   * One digest over the configured encodings and what each suffix held. A planted or altered
-   * variant misses because its own digest enters the fold. The empty marker buys the widening
-   * case: without a term for a suffix nothing was written to, a pass configured with one
-   * encoding and a pass configured with two that wrote only the first fold identically.
-   */
-  variants: string;
-}
-
 /**
  * What this process has already reconciled, by absolute path. Keyed on **content**, never on
  * the path alone: a later environment may rewrite a file an earlier pass handled, and a
  * path-keyed memo would skip it and leave the earlier bytes' variants in place.
  */
-const reconciled = new Map<string, Reconciled>();
+const reconciled = new Map<string, string>();

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { extname, join, posix, sep } from "node:path";
 import { promisify } from "node:util";
-import { brotliCompress, brotliDecompress, constants, gunzip, gzip } from "node:zlib";
+import { brotliCompress, constants, gzip } from "node:zlib";
 
 export type PrecompressEncoding = "br" | "gzip";
 
@@ -116,43 +116,17 @@ function ownsVariantsFor(filePath: string, relPath: string, context: Precompress
 }
 
 /**
- * Whether this file is already reconciled. Against a matching record the source is hashed and
- * the suffixes that pass wrote are confirmed present — the variants themselves are not read.
- * Without one, `decodesToSource` reads and compares them, which is what seeds the record.
+ * Whether this file is already reconciled: the source hashes to the record this process kept,
+ * and the suffixes that pass wrote are still on disk. Nothing on disk is read.
  */
 async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
   const key = lookupKey(source, resolved);
   const record = reconciled.get(filePath);
-  if (record?.startsWith(key) && (await stillWritten(filePath, record.slice(key.length)))) return true;
-
-  // For a directory that was already correct, this is the only place an entry is ever written:
-  // returning true here makes `processFile` return before reaching its own `remember`. Delete
-  // it and that state re-decodes on every later pass, having no other way to be recorded.
-  if (!(await decodesToSource(filePath, source, resolved))) return false;
-  remember(
-    filePath,
-    source,
-    resolved,
-    resolved.encodings.map((e) => CODECS[e].ext),
-  );
-  return true;
+  if (record === undefined || !record.startsWith(key)) return false;
+  return stillWritten(filePath, record.slice(key.length));
 }
 
-/** Whether every configured variant decodes to exactly the identity beside it. A missing
- *  variant, a decode failure, or any difference means reconcile. */
-async function decodesToSource(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
-  for (const encoding of resolved.encodings) {
-    const codec = CODECS[encoding];
-    // Unreadable for any reason means not usable as-is — the reconcile loop then deals with it.
-    const bytes = await readFile(filePath + codec.ext).catch(() => null);
-    if (!bytes || !notLarger(source, bytes)) return false;
-    const decoded = await codec.decode(bytes).catch(() => null);
-    if (!decoded || !decoded.equals(source)) return false;
-  }
-  return true;
-}
-
-/** Record what this pass reconciled, so later passes skip on a hash instead of a decode. */
+/** Record what this pass reconciled, so later passes settle it with a hash. */
 function remember(filePath: string, source: Buffer, resolved: ResolvedPrecompress, wrote: readonly string[]): void {
   reconciled.set(filePath, recordOf(source, resolved, wrote));
 }
@@ -263,18 +237,13 @@ const brotliAsync = promisify(brotliCompress);
 
 const gzipAsync = promisify(gzip);
 
-const brotliDecompressAsync = promisify(brotliDecompress);
-
-const gunzipAsync = promisify(gunzip);
-
 interface Codec {
   /** Suffix of the variant file, and the value srvx is handed to look one up. */
   ext: string;
   encode: (source: Buffer) => Promise<Buffer>;
-  decode: (bytes: Buffer) => Promise<Buffer>;
 }
 
-/** Everything one encoding needs — suffix, encode, decode — in one entry, checked against
+/** Everything one encoding needs — suffix and encoder — in one entry, checked against
  *  `PrecompressEncoding` so the table and the union cannot disagree. */
 const CODECS = {
   br: {
@@ -287,12 +256,10 @@ const CODECS = {
           [constants.BROTLI_PARAM_SIZE_HINT]: source.length,
         },
       }),
-    decode: (bytes) => brotliDecompressAsync(bytes),
   },
   gzip: {
     ext: ".gz",
     encode: (source) => gzipAsync(source, { level: constants.Z_BEST_COMPRESSION }),
-    decode: (bytes) => gunzipAsync(bytes),
   },
 } satisfies Record<PrecompressEncoding, Codec>;
 

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -246,7 +246,7 @@ async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPre
 }
 
 /** Record what these exact bytes reconciled to, so later passes verify by hash rather than by
- *  decode. Only `reconcile` records: it is the one place that knows what was written. */
+ *  decode. */
 function remember(
   filePath: string,
   source: Buffer,

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -237,8 +237,9 @@ async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPre
     if (await matchesRecord(filePath, resolved, memo.wrote)) return true;
   }
 
-  // A directory that was already correct on entry — an incremental rebuild — is recorded here
-  // too, so the environments after this one verify by hash rather than decoding again.
+  // For a directory that was already correct, this is the only place an entry is ever written:
+  // returning true here makes `processFile` return before reaching its own `remember`. Delete
+  // it and that state re-decodes on every later pass, having no other way to be recorded.
   const verified = await decodesToSource(filePath, source, resolved);
   if (verified) remember(filePath, source, resolved, verified);
   return verified !== null;

--- a/packages/adapter-node/src/precompress.ts
+++ b/packages/adapter-node/src/precompress.ts
@@ -15,8 +15,8 @@ export interface PrecompressOptions {
    */
   encodings?: PrecompressEncoding[];
   /**
-   * Minimum size, in bytes, of the original file. No upper bound: precompression is
-   * the only way to compress a file past srvx's 10 MiB on-the-fly ceiling.
+   * Minimum size, in bytes, of the original file. No upper bound — unlike srvx's on-the-fly
+   * path, precompression has no 10 MiB ceiling.
    *
    * @default 1024
    */
@@ -116,9 +116,9 @@ function ownsVariantsFor(filePath: string, relPath: string, context: Precompress
 }
 
 /**
- * Whether this file is already reconciled. A later pass hashes the source and confirms the
- * suffixes that pass wrote are still on disk; it does not read them, because whether a variant
- * is still valid is a question about request time, not build time.
+ * Whether this file is already reconciled. Against a matching record the source is hashed and
+ * the suffixes that pass wrote are confirmed present — the variants themselves are not read.
+ * Without one, `decodesToSource` reads and compares them, which is what seeds the record.
  */
 async function isCurrent(filePath: string, source: Buffer, resolved: ResolvedPrecompress): Promise<boolean> {
   const key = lookupKey(source, resolved);

--- a/packages/adapter-node/src/serve.ts
+++ b/packages/adapter-node/src/serve.ts
@@ -5,14 +5,6 @@ import type { Fetchable } from "@universal-deploy/store";
 import { type FetchHandler, type ServerMiddleware, serve as serveSrvx } from "srvx";
 import { type ResolvedStaticOptions, resolveStaticOptions } from "./static-options.js";
 
-function assertFetchable(mod: unknown, id: string): Fetchable {
-  if (!mod || typeof mod !== "object") throw new Error(`Missing default export from ${id}`);
-  if ("default" in mod && mod.default) mod = mod.default;
-  if (!mod || typeof mod !== "object" || !("fetch" in mod) || typeof mod.fetch !== "function")
-    throw new Error(`Default export from ${id} must include a { fetch() } function`);
-  return mod as Fetchable;
-}
-
 async function startServer() {
   assertFetchable(userServerEntry, "virtual:ud:catch-all");
   const { static: runtimeStatic } = userServerEntry as unknown as FetchHandler & {
@@ -60,6 +52,14 @@ async function startServer() {
   await server.ready();
 
   userServerEntry.onReady?.(server);
+}
+
+function assertFetchable(mod: unknown, id: string): Fetchable {
+  if (!mod || typeof mod !== "object") throw new Error(`Missing default export from ${id}`);
+  if ("default" in mod && mod.default) mod = mod.default;
+  if (!mod || typeof mod !== "object" || !("fetch" in mod) || typeof mod.fetch !== "function")
+    throw new Error(`Default export from ${id} must include a { fetch() } function`);
+  return mod as Fetchable;
 }
 
 await startServer();

--- a/packages/adapter-node/src/serve.ts
+++ b/packages/adapter-node/src/serve.ts
@@ -49,8 +49,8 @@ async function startServer() {
     gracefulShutdown: userServerEntry.gracefulShutdown ?? false,
     middleware: [
       ...(userServerEntry.middleware ?? []),
-      staticOptions && createStatic ? createStatic(staticOptions) : undefined,
-    ].filter(Boolean) as ServerMiddleware[],
+      ...(staticOptions && createStatic ? [createStatic(staticOptions)] : []),
+    ],
     manual: true,
   });
 

--- a/packages/adapter-node/src/serve.ts
+++ b/packages/adapter-node/src/serve.ts
@@ -1,8 +1,9 @@
-import { dirname, resolve } from "node:path";
+import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import userServerEntry from "virtual:ud:catch-all";
 import type { Fetchable } from "@universal-deploy/store";
 import { type FetchHandler, type ServerMiddleware, serve as serveSrvx } from "srvx";
+import { type ResolvedStaticOptions, resolveStaticOptions } from "./static-options.js";
 
 function assertFetchable(mod: unknown, id: string): Fetchable {
   if (!mod || typeof mod !== "object") throw new Error(`Missing default export from ${id}`);
@@ -14,29 +15,32 @@ function assertFetchable(mod: unknown, id: string): Fetchable {
 
 async function startServer() {
   assertFetchable(userServerEntry, "virtual:ud:catch-all");
-  let { static: staticHint } = userServerEntry as unknown as FetchHandler & {
+  const { static: runtimeStatic } = userServerEntry as unknown as FetchHandler & {
     static?: boolean | string;
   };
-
-  // @ts-expect-error replaced by node plugin
-  if (staticHint === undefined) staticHint = __UD_STATIC__;
 
   if (!process.env.NODE_ENV) {
     // @ts-expect-error replaced by node plugin
     process.env.NODE_ENV = __UD_PROD__ ? "production" : "development";
   }
 
-  // Resolve a string hint against this module's runtime location — keeps the
-  // built artifact portable across filesystems (Docker, deploy targets, …).
-  const staticDir =
-    typeof staticHint === "string" ? resolve(dirname(fileURLToPath(import.meta.url)), staticHint) : undefined;
+  // Resolved against this module's runtime location — keeps the built artifact
+  // portable across filesystems (Docker, deploy targets, …).
+  const staticOptions = resolveStaticOptions({
+    entryDir: dirname(fileURLToPath(import.meta.url)),
+    // @ts-expect-error replaced by node plugin
+    bakedStatic: __UD_STATIC__,
+    runtimeStatic,
+    // @ts-expect-error replaced by node plugin
+    encodings: __UD_ENCODINGS__,
+  });
 
-  // srvx 0.12 renamed `serveStatic` to `staticMiddleware` (same `{ dir }` signature).
+  // srvx 0.12 renamed `serveStatic` to `staticMiddleware` (same options shape).
   // Support both so the built server works against srvx 0.11 and 0.12+ alike. Only one
   // name exists in the installed srvx's types, hence the cast to a both-optional shape.
   const staticMod = (await import("srvx/static")) as unknown as {
-    staticMiddleware?: (options: { dir: string }) => ServerMiddleware;
-    serveStatic?: (options: { dir: string }) => ServerMiddleware;
+    staticMiddleware?: (options: ResolvedStaticOptions) => ServerMiddleware;
+    serveStatic?: (options: ResolvedStaticOptions) => ServerMiddleware;
   };
   const createStatic = staticMod.staticMiddleware ?? staticMod.serveStatic;
 
@@ -45,7 +49,7 @@ async function startServer() {
     gracefulShutdown: userServerEntry.gracefulShutdown ?? false,
     middleware: [
       ...(userServerEntry.middleware ?? []),
-      staticDir && createStatic ? createStatic({ dir: staticDir }) : undefined,
+      staticOptions && createStatic ? createStatic(staticOptions) : undefined,
     ].filter(Boolean) as ServerMiddleware[],
     manual: true,
   });

--- a/packages/adapter-node/src/static-options.ts
+++ b/packages/adapter-node/src/static-options.ts
@@ -35,9 +35,10 @@ export function resolveStaticOptions(input: StaticOptionsInput): ResolvedStaticO
   const dir = resolve(entryDir, effective);
 
   const bakedDir = typeof bakedStatic === "string" ? resolve(entryDir, bakedStatic) : undefined;
-  // Variants are only reconciled in the directory this build walked, so lookup is
-  // enabled only there. Comparison is exact: two spellings of one directory fall back
-  // to on-the-fly compression rather than risking variants no walk owns.
+  // Variants are only reconciled in the directory this build walked, so lookup is enabled
+  // only there. Both sides are already `resolve()`d, so `.`/`..` and separator differences
+  // compare equal; a case difference or a symlink alias does not, and falls back to
+  // on-the-fly compression rather than trusting variants no walk owns.
   const reconciled = bakedDir !== undefined && dir === bakedDir;
 
   return encodings && reconciled ? { dir, encodings } : { dir };

--- a/packages/adapter-node/src/static-options.ts
+++ b/packages/adapter-node/src/static-options.ts
@@ -41,5 +41,9 @@ export function resolveStaticOptions(input: StaticOptionsInput): ResolvedStaticO
   // on-the-fly compression rather than trusting variants no walk owns.
   const reconciled = bakedDir !== undefined && dir === bakedDir;
 
+  // `renderHTML` is deliberately never passed: srvx computes
+  // `compressible = !renderHTML && isCompressible(contentType)` (static.ts:388-392), so
+  // setting it would skip variant probing for text/html entirely — every `.html.br` we
+  // emit would still be written and silently never served.
   return encodings && reconciled ? { dir, encodings } : { dir };
 }

--- a/packages/adapter-node/src/static-options.ts
+++ b/packages/adapter-node/src/static-options.ts
@@ -1,0 +1,44 @@
+// Imported by serve.ts, so this module ships inside every built server: it must
+// import nothing build-time.
+import { resolve } from "node:path";
+
+export interface StaticOptionsInput {
+  /** Directory of the running server entry — what a relative hint resolves against. */
+  entryDir: string;
+  /** `__UD_STATIC__`: the entry-relative hint baked at build time, or `false`. */
+  bakedStatic: string | false;
+  /** The server entry's own `static`, which overrides the baked hint. */
+  runtimeStatic: string | boolean | undefined;
+  /** `__UD_ENCODINGS__`: the variant suffixes this build emitted, or `false`. */
+  encodings: Record<string, string> | false;
+}
+
+export interface ResolvedStaticOptions {
+  dir: string;
+  encodings?: Record<string, string>;
+}
+
+/**
+ * Decide whether to serve static files, from where, and whether precompressed
+ * variants may be looked up.
+ *
+ * Both directories are resolved here, at runtime, from `entryDir` — neither is a
+ * build-machine path, so a relocated build (Docker, build-here-serve-there) still
+ * compares equal.
+ */
+export function resolveStaticOptions(input: StaticOptionsInput): ResolvedStaticOptions | undefined {
+  const { entryDir, bakedStatic, runtimeStatic, encodings } = input;
+
+  const effective = runtimeStatic ?? bakedStatic;
+  // A non-string value — `false`, `true`, or nothing at all — means no static middleware.
+  if (typeof effective !== "string") return undefined;
+  const dir = resolve(entryDir, effective);
+
+  const bakedDir = typeof bakedStatic === "string" ? resolve(entryDir, bakedStatic) : undefined;
+  // Variants are only reconciled in the directory this build walked, so lookup is
+  // enabled only there. Comparison is exact: two spellings of one directory fall back
+  // to on-the-fly compression rather than risking variants no walk owns.
+  const reconciled = bakedDir !== undefined && dir === bakedDir;
+
+  return encodings && reconciled ? { dir, encodings } : { dir };
+}

--- a/packages/adapter-node/src/static-options.ts
+++ b/packages/adapter-node/src/static-options.ts
@@ -18,32 +18,27 @@ export interface ResolvedStaticOptions {
   encodings?: Record<string, string>;
 }
 
-/**
- * Decide whether to serve static files, from where, and whether precompressed
- * variants may be looked up.
- *
- * Both directories are resolved here, at runtime, from `entryDir` — neither is a
- * build-machine path, so a relocated build (Docker, build-here-serve-there) still
- * compares equal.
- */
+/** Absolute directory to serve, or `undefined` when static serving is off. The server
+ *  entry's own `static` overrides the hint baked at build time. */
+function servedDir(entryDir: string, baked: string | false, runtime: string | boolean | undefined): string | undefined {
+  const effective = runtime ?? baked;
+  if (typeof effective !== "string") return undefined;
+  return resolve(entryDir, effective);
+}
+
+/** Whether `dir` is the directory this build precompressed. Both sides resolve at runtime
+ *  from `entryDir`, so a relocated build still compares equal. */
+function servesThisBuildsOutput(entryDir: string, baked: string | false, dir: string): boolean {
+  return typeof baked === "string" && dir === resolve(entryDir, baked);
+}
+
+/** Whether to serve static files, from where, and whether variants may be looked up. */
 export function resolveStaticOptions(input: StaticOptionsInput): ResolvedStaticOptions | undefined {
   const { entryDir, bakedStatic, runtimeStatic, encodings } = input;
 
-  const effective = runtimeStatic ?? bakedStatic;
-  // A non-string value — `false`, `true`, or nothing at all — means no static middleware.
-  if (typeof effective !== "string") return undefined;
-  const dir = resolve(entryDir, effective);
+  const dir = servedDir(entryDir, bakedStatic, runtimeStatic);
+  if (dir === undefined) return undefined;
 
-  const bakedDir = typeof bakedStatic === "string" ? resolve(entryDir, bakedStatic) : undefined;
-  // Variants are only reconciled in the directory this build walked, so lookup is enabled
-  // only there. Both sides are already `resolve()`d, so `.`/`..` and separator differences
-  // compare equal; a case difference or a symlink alias does not, and falls back to
-  // on-the-fly compression rather than trusting variants no walk owns.
-  const reconciled = bakedDir !== undefined && dir === bakedDir;
-
-  // `renderHTML` is deliberately never passed: srvx computes
-  // `compressible = !renderHTML && isCompressible(contentType)` (static.ts:388-392), so
-  // setting it would skip variant probing for text/html entirely — every `.html.br` we
-  // emit would still be written and silently never served.
-  return encodings && reconciled ? { dir, encodings } : { dir };
+  const serveVariants = encodings && servesThisBuildsOutput(entryDir, bakedStatic, dir);
+  return serveVariants ? { dir, encodings } : { dir };
 }

--- a/packages/adapter-node/src/static-options.ts
+++ b/packages/adapter-node/src/static-options.ts
@@ -18,6 +18,17 @@ export interface ResolvedStaticOptions {
   encodings?: Record<string, string>;
 }
 
+/** Whether to serve static files, from where, and whether variants may be looked up. */
+export function resolveStaticOptions(input: StaticOptionsInput): ResolvedStaticOptions | undefined {
+  const { entryDir, bakedStatic, runtimeStatic, encodings } = input;
+
+  const dir = servedDir(entryDir, bakedStatic, runtimeStatic);
+  if (dir === undefined) return undefined;
+
+  const serveVariants = encodings && servesThisBuildsOutput(entryDir, bakedStatic, dir);
+  return serveVariants ? { dir, encodings } : { dir };
+}
+
 /** Absolute directory to serve, or `undefined` when static serving is off. The server
  *  entry's own `static` overrides the hint baked at build time. */
 function servedDir(entryDir: string, baked: string | false, runtime: string | boolean | undefined): string | undefined {
@@ -30,15 +41,4 @@ function servedDir(entryDir: string, baked: string | false, runtime: string | bo
  *  from `entryDir`, so a relocated build still compares equal. */
 function servesThisBuildsOutput(entryDir: string, baked: string | false, dir: string): boolean {
   return typeof baked === "string" && dir === resolve(entryDir, baked);
-}
-
-/** Whether to serve static files, from where, and whether variants may be looked up. */
-export function resolveStaticOptions(input: StaticOptionsInput): ResolvedStaticOptions | undefined {
-  const { entryDir, bakedStatic, runtimeStatic, encodings } = input;
-
-  const dir = servedDir(entryDir, bakedStatic, runtimeStatic);
-  if (dir === undefined) return undefined;
-
-  const serveVariants = encodings && servesThisBuildsOutput(entryDir, bakedStatic, dir);
-  return serveVariants ? { dir, encodings } : { dir };
 }

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -138,7 +138,7 @@ export function node(options?: {
       apply: "build",
       // The memo records which source and configuration this build already reconciled, and a
       // later build may empty the output directory, so a record that outlived a build would
-      // describe files that are gone.
+      // claim a reconciliation whose variants are no longer there.
       // `configResolved` fires before any environment's `buildStart`, so clearing here resets
       // between builds without clearing between the client and ssr passes of one.
       configResolved() {

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -13,6 +13,7 @@ import {
 import {
   collectRelativeFiles,
   encodingsMap,
+  forgetReconciled,
   type PrecompressOptions,
   precompressDir,
   resolvePrecompress,
@@ -131,10 +132,17 @@ export function node(options?: {
     // Runs at EVERY environment's `closeBundle`, not just the client's: a framework may
     // write more servable files from a later environment — vike pre-renders HTML inside
     // the ssr environment's `writeBundle` — and those would otherwise never be seen.
-    // A later pass still walks and verifies; what it skips is re-encoding what is current.
+    // A later pass still walks; what it skips is re-encoding what this build already did.
     {
       name: "ud:node:precompress",
       apply: "build",
+      // The memo records what this build put on disk. Vite empties the output directory before
+      // the next one, so a record that outlived a build would describe files that are gone.
+      // `configResolved` fires before any environment's `buildStart`, so clearing here resets
+      // between builds without clearing between the client and ssr passes of one.
+      configResolved() {
+        forgetReconciled();
+      },
       // No `applyToEnvironment`: emission is not scoped to one environment. Excluding any
       // environment would drop the files it alone writes — vike pre-renders HTML inside the
       // ssr environment — and nothing later would ever look at them.

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -10,6 +10,13 @@ import {
   normalizePath,
   type Plugin,
 } from "vite";
+import {
+  collectRelativeFiles,
+  encodingsMap,
+  type PrecompressOptions,
+  precompressDir,
+  resolvePrecompress,
+} from "./precompress.js";
 
 // @ts-expect-error Bun global
 const isBun = typeof Bun !== "undefined";
@@ -48,7 +55,18 @@ export function resolveStaticHint(env: Environment, configured: string | boolean
 }
 
 // Creates a server and listens for connections in Node/Deno/Bun
-export function node(options?: { static?: string | boolean; importer?: string }): Plugin[] {
+export function node(options?: {
+  static?: string | boolean;
+  importer?: string;
+  /**
+   * Emit `.br`/`.gz` variants of the served static assets at build time and serve
+   * them instead of compressing on every request.
+   *
+   * @default false
+   */
+  precompress?: boolean | PrecompressOptions;
+}): Plugin[] {
+  const precompress = resolvePrecompress(options?.precompress);
   return [
     // Resolves virtual:ud:node-entry to its node runtime id
     {
@@ -89,12 +107,15 @@ export function node(options?: { static?: string | boolean; importer?: string })
 
       transform: {
         filter: {
-          code: [/__UD_STATIC__/, /__UD_PROD__/],
+          code: [/__UD_STATIC__/, /__UD_PROD__/, /__UD_ENCODINGS__/],
         },
         handler(code) {
           const s = new MagicString(code);
           s.replace(/__UD_STATIC__/g, JSON.stringify(resolveStaticHint(this.environment, options?.static)));
           s.replace(/__UD_PROD__/g, JSON.stringify(true));
+          // Derived from the same resolved object that drives emission, so the suffixes
+          // served and the suffixes written cannot disagree.
+          s.replace(/__UD_ENCODINGS__/g, JSON.stringify(precompress ? encodingsMap(precompress) : false));
           if (s.hasChanged()) {
             return {
               code: s.toString(),
@@ -102,6 +123,28 @@ export function node(options?: { static?: string | boolean; importer?: string })
             };
           }
         },
+      },
+    },
+    // Emit precompressed variants beside the static assets, once they are on disk.
+    // `closeBundle` on the client environment is the only hook that sees both the
+    // emitted assets and the `publicDir` copies (Vite copies those in `renderStart`).
+    {
+      name: "ud:node:precompress",
+      apply: "build",
+      // `PartialEnvironment` carries no `consumer` of its own; it lives on its config.
+      applyToEnvironment: (environment) => environment.config.consumer === "client",
+      async closeBundle() {
+        if (!precompress) return;
+        const dir = resolveStaticDir(this.environment, options?.static);
+        if (dir === undefined) return;
+
+        const { publicDir, build } = this.environment.config;
+        // Pass-throughs are re-copied from source every build, so their variants are
+        // the user's: neither emitted nor retired here.
+        const passThrough = build.copyPublicDir && publicDir ? await collectRelativeFiles(publicDir) : undefined;
+
+        const { written } = await precompressDir(dir, precompress, { passThrough });
+        this.environment.logger.info(`precompressed ${written} variants`);
       },
     },
     // Bun and Deno conditions

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -136,8 +136,9 @@ export function node(options?: {
     {
       name: "ud:node:precompress",
       apply: "build",
-      // The memo records what this build put on disk, and a later build may empty the output
-      // directory, so a record that outlived a build would describe files that are gone.
+      // The memo records which source and configuration this build already reconciled, and a
+      // later build may empty the output directory, so a record that outlived a build would
+      // describe files that are gone.
       // `configResolved` fires before any environment's `buildStart`, so clearing here resets
       // between builds without clearing between the client and ssr passes of one.
       configResolved() {

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -135,21 +135,30 @@ export function node(options?: {
     {
       name: "ud:node:precompress",
       apply: "build",
-      async closeBundle() {
-        if (!precompress) return;
-        // The client's directory in every pass, including the ssr one — the walk targets
-        // what is served, not what the current environment emitted.
-        const dir = resolveStaticDir(this.environment, options?.static);
-        if (dir === undefined) return;
+      // No `applyToEnvironment`: emission is not scoped to one environment. Excluding any
+      // environment would drop the files it alone writes — vike pre-renders HTML inside the
+      // ssr environment — and nothing later would ever look at them.
+      closeBundle: {
+        // Runs after the default-order `closeBundle` hooks, so files they write are in the
+        // walk. (`sequential` adds nothing: rolldown runs every hook sequentially already,
+        // and deprecates the option.)
+        order: "post",
+        async handler() {
+          if (!precompress) return;
+          // The client's directory in every pass, including the ssr one — the walk targets
+          // what is served, not what the current environment emitted.
+          const dir = resolveStaticDir(this.environment, options?.static);
+          if (dir === undefined) return;
 
-        const { publicDir, build } = this.environment.config;
-        // Pass-throughs are re-copied from source every build, so their variants are
-        // the user's: neither emitted nor retired here.
-        const passThrough = build.copyPublicDir && publicDir ? await collectRelativeFiles(publicDir) : undefined;
+          const { publicDir, build } = this.environment.config;
+          // Pass-throughs are re-copied from source every build, so their variants are
+          // the user's: neither emitted nor retired here.
+          const passThrough = build.copyPublicDir && publicDir ? await collectRelativeFiles(publicDir) : undefined;
 
-        const { written } = await precompressDir(dir, precompress, { passThrough });
-        // A later environment's pass usually has nothing left to do; stay quiet then.
-        if (written > 0) this.environment.logger.info(`precompressed ${written} variants`);
+          const { written } = await precompressDir(dir, precompress, { passThrough });
+          // A later environment's pass usually has nothing left to do; stay quiet then.
+          if (written > 0) this.environment.logger.info(`precompressed ${written} variants`);
+        },
       },
     },
     // Bun and Deno conditions

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -225,4 +225,6 @@ export function node(options?: {
   ];
 }
 
+export type { PrecompressEncoding, PrecompressOptions } from "./precompress.js";
+
 export default node;

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -13,7 +13,6 @@ import {
 import {
   collectRelativeFiles,
   encodingsMap,
-  forgetReconciled,
   type PrecompressOptions,
   precompressDir,
   resolvePrecompress,
@@ -132,18 +131,10 @@ export function node(options?: {
     // Runs at EVERY environment's `closeBundle`, not just the client's: a framework may
     // write more servable files from a later environment — vike pre-renders HTML inside
     // the ssr environment's `writeBundle` — and those would otherwise never be seen.
-    // A later pass still walks; what it skips is re-encoding what this build already did.
+    // A later pass still walks; what it skips is re-encoding what an earlier pass already did.
     {
       name: "ud:node:precompress",
       apply: "build",
-      // The memo records which source and configuration this build already reconciled, and a
-      // later build may empty the output directory, so a record that outlived a build would
-      // claim a reconciliation whose variants are no longer there.
-      // `configResolved` fires before any environment's `buildStart`, so clearing here resets
-      // between builds without clearing between the client and ssr passes of one.
-      configResolved() {
-        forgetReconciled();
-      },
       // No `applyToEnvironment`: emission is not scoped to one environment. Excluding any
       // environment would drop the files it alone writes — vike pre-renders HTML inside the
       // ssr environment — and nothing later would ever look at them.

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -126,13 +126,13 @@ export function node(options?: {
       },
     },
     // Emit precompressed variants beside the static assets, once they are on disk.
-    // `closeBundle` on the client environment is the only hook that sees both the
-    // emitted assets and the `publicDir` copies (Vite copies those in `renderStart`).
+    // Runs at EVERY environment's `closeBundle`, not just the client's: a framework may
+    // write more servable files from a later environment — vike pre-renders HTML inside
+    // the ssr environment's `writeBundle` — and those would otherwise never be seen.
+    // Repeat passes are near-free; `precompressDir` skips what is already current.
     {
       name: "ud:node:precompress",
       apply: "build",
-      // `PartialEnvironment` carries no `consumer` of its own; it lives on its config.
-      applyToEnvironment: (environment) => environment.config.consumer === "client",
       async closeBundle() {
         if (!precompress) return;
         const dir = resolveStaticDir(this.environment, options?.static);
@@ -144,7 +144,8 @@ export function node(options?: {
         const passThrough = build.copyPublicDir && publicDir ? await collectRelativeFiles(publicDir) : undefined;
 
         const { written } = await precompressDir(dir, precompress, { passThrough });
-        this.environment.logger.info(`precompressed ${written} variants`);
+        // A later environment's pass usually has nothing left to do; stay quiet then.
+        if (written > 0) this.environment.logger.info(`precompressed ${written} variants`);
       },
     },
     // Bun and Deno conditions

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -129,7 +129,7 @@ export function node(options?: {
     // Runs at EVERY environment's `closeBundle`, not just the client's: a framework may
     // write more servable files from a later environment — vike pre-renders HTML inside
     // the ssr environment's `writeBundle` — and those would otherwise never be seen.
-    // Repeat passes are near-free; `precompressDir` skips what is already current.
+    // A later pass still walks and verifies; what it skips is re-encoding what is current.
     {
       name: "ud:node:precompress",
       apply: "build",

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -136,8 +136,8 @@ export function node(options?: {
     {
       name: "ud:node:precompress",
       apply: "build",
-      // The memo records what this build put on disk. Vite empties the output directory before
-      // the next one, so a record that outlived a build would describe files that are gone.
+      // The memo records what this build put on disk, and a later build may empty the output
+      // directory, so a record that outlived a build would describe files that are gone.
       // `configResolved` fires before any environment's `buildStart`, so clearing here resets
       // between builds without clearing between the client and ssr passes of one.
       configResolved() {

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -30,8 +30,10 @@ function findClientOutDir(env: Environment) {
 }
 
 /** Absolute path of the directory that will be served, or `undefined` when static
- *  serving is off. Vite leaves `build.outDir` and a configured path relative to
- *  `config.root`, so both are anchored to it rather than to `process.cwd()`. */
+ *  serving is off. Always the **client** environment's directory, whichever environment
+ *  is passed — `env` supplies only the shared top-level config and root. Vite leaves
+ *  `build.outDir` and a configured path relative to `config.root`, so both are anchored
+ *  to it rather than to `process.cwd()`. */
 export function resolveStaticDir(env: Environment, configured: string | boolean | undefined): string | undefined {
   if (configured === false) return undefined;
   const path = typeof configured === "string" ? configured : findClientOutDir(env);
@@ -135,6 +137,8 @@ export function node(options?: {
       apply: "build",
       async closeBundle() {
         if (!precompress) return;
+        // The client's directory in every pass, including the ssr one — the walk targets
+        // what is served, not what the current environment emitted.
         const dir = resolveStaticDir(this.environment, options?.static);
         if (dir === undefined) return;
 

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -43,4 +43,5 @@ The `universalDeploy()` plugin accepts the following options:
 - `node`: Same options as the `@universal-deploy/node` adapter:
     - `static`: (string | boolean) The directory containing static assets. Defaults to the client output directory.
     - `importer`: (string) The importer to use when resolving the server entry.
+    - `precompress`: (boolean | object) Emit `.br`/`.gz` variants of the static assets at build time and serve those instead of compressing per request. Off by default; see the [adapter README](../adapter-node/README.md#precompress).
 - `entry`: (string) Relative or absolute path to override the default server entry.

--- a/tests/e2e/tests/index.spec.ts
+++ b/tests/e2e/tests/index.spec.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs/promises";
-import path from "node:path";
 import { expect, type Page, test } from "@playwright/test";
 import { goto } from "./utils.js";
 
@@ -23,34 +21,6 @@ test("page is rendered to the DOM and interactive", async ({ page }) => {
 test("/api", async ({ request }) => {
   const response = await request.get("/api");
   expect(await response.text()).toBe("The API Route");
-});
-
-test("precompressed asset is served from disk", async ({ request }) => {
-  test.skip(!process.env.UD_PRECOMPRESS, "app does not enable precompression");
-  test.skip(!process.env.RUN_CMD, "production build only");
-
-  // An asset with a variant beside it. Finding none is a failure, not a skip: the
-  // build is supposed to have produced one.
-  const root = path.join(process.cwd(), "dist/client");
-  const entries = await fs.readdir(root, { recursive: true, withFileTypes: true });
-  const variant = entries
-    .filter((entry) => entry.isFile() && entry.name.endsWith(".br"))
-    .map((entry) => path.relative(root, path.join(entry.parentPath, entry.name)))
-    // Prefer a fingerprinted asset — its URL is stable and it is never rendered.
-    .sort((a, b) => Number(b.startsWith("assets")) - Number(a.startsWith("assets")))[0];
-  expect(variant, `no .br variant under ${root}`).toBeTruthy();
-
-  const identity = (variant as string).slice(0, -".br".length);
-  const size = (await fs.stat(path.join(root, variant as string))).size;
-
-  const url = `/${identity.split(path.sep).join("/")}`;
-  const response = await request.get(url, { headers: { "accept-encoding": "br" } });
-  expect(response.status()).toBe(200);
-  const headers = response.headers();
-  expect(headers["content-encoding"]).toBe("br");
-  // The discriminator: an on-the-fly encode is chunked and carries no length, so this
-  // is what separates serving the file from re-encoding it.
-  expect(headers["content-length"]).toBe(String(size));
 });
 
 async function testCounter(page: Page, currentValue = 0) {

--- a/tests/e2e/tests/index.spec.ts
+++ b/tests/e2e/tests/index.spec.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { expect, type Page, test } from "@playwright/test";
 import { goto } from "./utils.js";
 
@@ -21,6 +23,34 @@ test("page is rendered to the DOM and interactive", async ({ page }) => {
 test("/api", async ({ request }) => {
   const response = await request.get("/api");
   expect(await response.text()).toBe("The API Route");
+});
+
+test("precompressed asset is served from disk", async ({ request }) => {
+  test.skip(!process.env.UD_PRECOMPRESS, "app does not enable precompression");
+  test.skip(!process.env.RUN_CMD, "production build only");
+
+  // An asset with a variant beside it. Finding none is a failure, not a skip: the
+  // build is supposed to have produced one.
+  const root = path.join(process.cwd(), "dist/client");
+  const entries = await fs.readdir(root, { recursive: true, withFileTypes: true });
+  const variant = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".br"))
+    .map((entry) => path.relative(root, path.join(entry.parentPath, entry.name)))
+    // Prefer a fingerprinted asset — its URL is stable and it is never rendered.
+    .sort((a, b) => Number(b.startsWith("assets")) - Number(a.startsWith("assets")))[0];
+  expect(variant, `no .br variant under ${root}`).toBeTruthy();
+
+  const identity = (variant as string).slice(0, -".br".length);
+  const size = (await fs.stat(path.join(root, variant as string))).size;
+
+  const url = `/${identity.split(path.sep).join("/")}`;
+  const response = await request.get(url, { headers: { "accept-encoding": "br" } });
+  expect(response.status()).toBe(200);
+  const headers = response.headers();
+  expect(headers["content-encoding"]).toBe("br");
+  // The discriminator: an on-the-fly encode is chunked and carries no length, so this
+  // is what separates serving the file from re-encoding it.
+  expect(headers["content-length"]).toBe(String(size));
 });
 
 async function testCounter(page: Page, currentValue = 0) {

--- a/tests/e2e/tests/precompress.spec.ts
+++ b/tests/e2e/tests/precompress.spec.ts
@@ -2,6 +2,23 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
 
+test("an HTML variant is served from disk", async ({ request }, testInfo) => {
+  test.skip(!testInfo.config.metadata.precompress, "app does not enable precompression");
+  test.skip(!process.env.RUN_CMD, "production build only");
+
+  // srvx skips variant probing for text/html when its `renderHTML` option is set, so this
+  // asserts the adapter has not adopted it: the variants would still be emitted, silently
+  // never served, with no error and nothing else failing.
+  const variant = path.join(process.cwd(), "dist/client/index.html.br");
+  const size = (await fs.stat(variant)).size;
+
+  const response = await request.get("/index.html", { headers: { "accept-encoding": "br" } });
+  expect(response.status()).toBe(200);
+  const headers = response.headers();
+  expect(headers["content-encoding"]).toBe("br");
+  expect(headers["content-length"]).toBe(String(size));
+});
+
 test("a precompressed variant is served from disk", async ({ request }, testInfo) => {
   test.skip(!testInfo.config.metadata.precompress, "app does not enable precompression");
   test.skip(!process.env.RUN_CMD, "production build only");

--- a/tests/e2e/tests/precompress.spec.ts
+++ b/tests/e2e/tests/precompress.spec.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+
+test("a precompressed variant is served from disk", async ({ request }, testInfo) => {
+  test.skip(!testInfo.config.metadata.precompress, "app does not enable precompression");
+  test.skip(!process.env.RUN_CMD, "production build only");
+
+  const root = path.join(process.cwd(), "dist/client");
+  const entries = await fs.readdir(root, { recursive: true, withFileTypes: true });
+  const variants = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".br"))
+    .map((entry) => path.relative(root, path.join(entry.parentPath, entry.name)));
+  // Prefer a fingerprinted asset: its URL is stable and it is never rendered. Finding
+  // none is a failure, not a skip — the build is supposed to have produced one.
+  const variant = variants.find((name) => name.startsWith("assets")) ?? variants[0];
+  if (!variant) throw new Error(`no .br variant under ${root}`);
+
+  const identity = variant.slice(0, -".br".length);
+  const size = (await fs.stat(path.join(root, variant))).size;
+
+  const response = await request.get(`/${identity.split(path.sep).join("/")}`, {
+    headers: { "accept-encoding": "br" },
+  });
+  expect(response.status()).toBe(200);
+  const headers = response.headers();
+  expect(headers["content-encoding"]).toBe("br");
+  // The discriminator: an on-the-fly encode is chunked and carries no length, so this is
+  // what separates serving the file from re-encoding it.
+  expect(headers["content-length"]).toBe(String(size));
+});


### PR DESCRIPTION
Implements the server half of vikejs/vike#3451. The two fixes this PR was chained behind — #36 (srvx ^0.12, fixes #34) and #37 (path-resolution) — are merged and released in `@universal-deploy/node@0.1.10`, so this PR now carries only its own commits, rebased onto main.

## The feature

```ts
node({ precompress: true })   // or { encodings?: ("br"|"gzip")[], threshold?: number }
```

**Off by default** — whether it should become the self-hosted default is left to you. At every environment's `closeBundle`: emit `.br`/`.gz` for srvx-negotiable files ≥ `threshold` (default 1024 B) when the variant is no larger than the original, and enable srvx's `encodings` lookup so they're served with a known `Content-Length` and zero request-path compression. Later passes cover files an earlier pass couldn't see — vike pre-renders HTML during its ssr environment, and those pages get variants too. Everything else is left to srvx's own static handling, which compresses on the fly only for compressible non-range requests between 1 KiB and 10 MiB.

## Keeping variants in sync

Variants track their sources: a file that earns one has it, a file that no longer does has it removed — relevant with `build.emptyOutDir: false`, where a variant it created would otherwise serve a previous build's bytes under the current URL with a valid ETag. Orphans and `publicDir` variants are left alone: an orphan is unreachable, since srvx 404s the identity before probing for a variant, but a `publicDir` variant *is* served, so that one is yours to keep current. Within one build, a later pass does not redo work an earlier pass already did. It does not re-verify the contents of a variant it already wrote. No in-repo writer produces a corrupt one — a second compression plugin produces a valid variant — and this pass is not guaranteed to run last, so a re-read would police a state the build does not own, at a cost paid on every memo-eligible file it owns on every later pass. What that saves is the re-encoding. Later passes measured 19 ms with the record against 182 ms without it on 300 files of 4 KB, and 56 ms against 798 ms on 300 files of 200 KB.

## Deliberately not included (per vikejs/vike#3451's ask)

`compress`, `maxAge`, `immutable` stay at srvx defaults (disabling `compress` would regress files that a raised `threshold` excludes but srvx would still compress; cache policy deserves its own review). An `extensions` knob was dropped — the eligible set mirrors srvx 0.12's negotiable MIME types, since a variant outside them could never be served.

## Safety guard

`encodings` is enabled only when the effective serve directory resolves to the one this build reconciled. An absent runtime `static` uses the baked hint; a non-string effective value means no static middleware at all. A `prod.static` override resolving to the same path keeps `encodings`; one resolving elsewhere serves those files without looking for variants. Relocation-safe where it can be: a relative baked hint with no runtime override resolves both sides of the comparison against the server entry's directory (verified incl. Docker). An absolute configured `static` is baked as given, and a runtime override is compared against the baked hint — neither is guaranteed to be entry-relative.

## Limitations

- Pages pre-rendered by a separate `$ vike prerender` run get no variants — no build runs to create them. Pre-rendering as part of `vike build` is covered.
- A server entry deployed against a different build's client tree is out of reach; documented.
- Variants of previously-configured encodings are inert leftovers (srvx never probes suffixes outside the current map).
- A variant altered after the build wrote it is served as-is. The build does not re-check what it has already written: keeping a variant intact after the build exits is outside what the build owns.
- Variants you ship in `publicDir` become live: `encodings` is a directory-wide lookup, so your own `.br`/`.gz` is served, while the precompression pass never generates or removes it. Keeping it in step with its source is yours — including HTML, since srvx probes variants for `text/html` too.

## Verification

Node 20/22/24, Bun, and Deno e2e lanes pass with the test proven executed (pass-count differential). Pre-render coverage was verified through a real vike build with pre-rendering enabled: 3 pages → 3 `.br` + 3 `.gz`, served by the production server. The load-bearing assertion is `content-length == on-disk variant size` — `content-encoding: br` alone is true even without the feature (on-the-fly compression), and disk emission alone is true even when srvx ignores the file. When reading the example output: its ~840 B JS bundle correctly gets no variant (below threshold); the larger CSS/HTML do. `precompress.spec.ts` is a new file because `vite.spec.ts` can't give a fail-closed exit code on Windows (4 pre-existing platform-assumption failures, untouched to keep the diff minimal).

Paired Vike PR (config + docs, boolean pass-through) opens against this package's next release.
