### PR TITLE
fix(adapter-node): update srvx to ^0.12

### DIFF
--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@universal-deploy/store": "workspace:^",
     "magic-string": "^0.30.21",
-    "srvx": "^0.11.9"
+    "srvx": "^0.12.5"
   },
   "peerDependencies": {
     "vite": ">=7.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
     dependencies:
       '@universal-middleware/core':
         specifier: ^0.4.17
-        version: 0.4.17(h3@1.15.11)(hono@4.12.5)(srvx@0.11.9)
+        version: 0.4.17(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)
       awesome-framework:
         specifier: 0.0.0
         version: link:../../tests/awesome-framework
@@ -62,14 +62,14 @@ importers:
     dependencies:
       '@universal-middleware/core':
         specifier: ^0.4.17
-        version: 0.4.17(h3@1.15.11)(hono@4.12.5)(srvx@0.11.9)
+        version: 0.4.17(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)
       awesome-framework:
         specifier: 0.0.0
         version: link:../../tests/awesome-framework
     devDependencies:
       '@netlify/vite-plugin':
         specifier: ^2.11.3
-        version: 2.11.3(rollup@4.53.5)(srvx@0.11.9)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 2.11.3(rollup@4.53.5)(srvx@0.12.5)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@universal-deploy/e2e':
         specifier: 'workspace:'
         version: link:../../tests/e2e
@@ -158,7 +158,7 @@ importers:
         version: 1.146.2(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@tanstack/react-router@1.146.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@tanstack/router-core@1.146.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-start':
         specifier: ^1.146.3
-        version: 1.146.3(crossws@0.4.4(srvx@0.11.9))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.146.3(crossws@0.4.4(srvx@0.12.5))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tanstack/router-plugin':
         specifier: ^1.146.3
         version: 1.146.3(@tanstack/react-router@1.146.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -222,7 +222,7 @@ importers:
         version: 8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
       vite-plugin-vercel:
         specifier: ^11.0.3
-        version: 11.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(h3@1.15.11)(hono@4.12.5)(rollup@4.53.5)(srvx@0.11.9)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 11.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(h3@1.15.11)(hono@4.12.5)(rollup@4.53.5)(srvx@0.12.5)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       web-vitals:
         specifier: ^5.1.0
         version: 5.1.0
@@ -252,8 +252,8 @@ importers:
         specifier: ^0.30.21
         version: 0.30.21
       srvx:
-        specifier: ^0.11.9
-        version: 0.11.9
+        specifier: ^0.12.5
+        version: 0.12.5
     devDependencies:
       '@types/node':
         specifier: ^22.19.15
@@ -309,7 +309,7 @@ importers:
         version: link:../store
       '@universal-middleware/express':
         specifier: ^0.4.26
-        version: 0.4.26(h3@1.15.11)(hono@4.12.5)(srvx@0.11.9)
+        version: 0.4.26(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
@@ -340,13 +340,13 @@ importers:
         version: link:../../packages/store
       '@universal-middleware/core':
         specifier: ^0.4.17
-        version: 0.4.17(h3@1.15.11)(hono@4.12.5)(srvx@0.11.9)
+        version: 0.4.17(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)
       '@universal-middleware/express':
         specifier: ^0.4.26
-        version: 0.4.26(h3@1.15.11)(hono@4.12.5)(srvx@0.11.9)
+        version: 0.4.26(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)
       '@universal-middleware/srvx':
         specifier: ^0.1.3
-        version: 0.1.3(h3@1.15.11)(hono@4.12.5)(srvx@0.11.9)
+        version: 0.1.3(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)
     devDependencies:
       '@types/node':
         specifier: ^22.19.15
@@ -3179,6 +3179,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -5221,6 +5222,11 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  srvx@0.12.5:
+    resolution: {integrity: sha512-IuvtDNQg5EIwv3c6dleyau7u8hCyGQ7D6+V/QM799Aud07z0wCUcurKLTRfyG33C8oUY+UWcVBFkfHMcbtmRLA==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
 
@@ -6944,7 +6950,7 @@ snapshots:
       uuid: 13.0.0
       write-file-atomic: 5.0.1
 
-  '@netlify/dev@4.16.5(rollup@4.53.5)(srvx@0.11.9)':
+  '@netlify/dev@4.16.5(rollup@4.53.5)(srvx@0.12.5)':
     dependencies:
       '@netlify/ai': 0.4.1
       '@netlify/blobs': 10.7.4
@@ -6954,7 +6960,7 @@ snapshots:
       '@netlify/edge-functions-dev': 1.0.16
       '@netlify/functions-dev': 1.2.5(rollup@4.53.5)
       '@netlify/headers': 2.1.8
-      '@netlify/images': 1.3.7(@netlify/blobs@10.7.4)(srvx@0.11.9)
+      '@netlify/images': 1.3.7(@netlify/blobs@10.7.4)(srvx@0.12.5)
       '@netlify/redirects': 3.1.10
       '@netlify/runtime': 4.1.20
       '@netlify/static': 3.1.7
@@ -7066,9 +7072,9 @@ snapshots:
     dependencies:
       '@netlify/headers-parser': 9.0.3
 
-  '@netlify/images@1.3.7(@netlify/blobs@10.7.4)(srvx@0.11.9)':
+  '@netlify/images@1.3.7(@netlify/blobs@10.7.4)(srvx@0.12.5)':
     dependencies:
-      ipx: 3.1.1(@netlify/blobs@10.7.4)(srvx@0.11.9)
+      ipx: 3.1.1(@netlify/blobs@10.7.4)(srvx@0.12.5)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -7139,9 +7145,9 @@ snapshots:
 
   '@netlify/types@2.6.0': {}
 
-  '@netlify/vite-plugin@2.11.3(rollup@4.53.5)(srvx@0.11.9)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@netlify/vite-plugin@2.11.3(rollup@4.53.5)(srvx@0.12.5)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@netlify/dev': 4.16.5(rollup@4.53.5)(srvx@0.11.9)
+      '@netlify/dev': 4.16.5(rollup@4.53.5)(srvx@0.12.5)
       '@netlify/dev-utils': 4.4.3
       dedent: 1.7.2
       vite: 8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -7929,27 +7935,27 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/react-start-server@1.146.2(crossws@0.4.4(srvx@0.11.9))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@tanstack/react-start-server@1.146.2(crossws@0.4.4(srvx@0.12.5))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@tanstack/history': 1.145.7
       '@tanstack/react-router': 1.146.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/router-core': 1.146.2
       '@tanstack/start-client-core': 1.146.2
-      '@tanstack/start-server-core': 1.146.2(crossws@0.4.4(srvx@0.11.9))
+      '@tanstack/start-server-core': 1.146.2(crossws@0.4.4(srvx@0.12.5))
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.146.3(crossws@0.4.4(srvx@0.11.9))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tanstack/react-start@1.146.3(crossws@0.4.4(srvx@0.12.5))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tanstack/react-router': 1.146.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-start-client': 1.146.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/react-start-server': 1.146.2(crossws@0.4.4(srvx@0.11.9))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/react-start-server': 1.146.2(crossws@0.4.4(srvx@0.12.5))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/router-utils': 1.143.11
       '@tanstack/start-client-core': 1.146.2
-      '@tanstack/start-plugin-core': 1.146.3(@tanstack/react-router@1.146.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(crossws@0.4.4(srvx@0.11.9))(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
-      '@tanstack/start-server-core': 1.146.2(crossws@0.4.4(srvx@0.11.9))
+      '@tanstack/start-plugin-core': 1.146.3(@tanstack/react-router@1.146.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(crossws@0.4.4(srvx@0.12.5))(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@tanstack/start-server-core': 1.146.2(crossws@0.4.4(srvx@0.12.5))
       pathe: 2.0.3
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -8051,7 +8057,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.143.8': {}
 
-  '@tanstack/start-plugin-core@1.146.3(@tanstack/react-router@1.146.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(crossws@0.4.4(srvx@0.11.9))(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tanstack/start-plugin-core@1.146.3(@tanstack/react-router@1.146.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(crossws@0.4.4(srvx@0.12.5))(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.28.5
@@ -8062,7 +8068,7 @@ snapshots:
       '@tanstack/router-plugin': 1.146.3(@tanstack/react-router@1.146.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tanstack/router-utils': 1.143.11
       '@tanstack/start-client-core': 1.146.2
-      '@tanstack/start-server-core': 1.146.2(crossws@0.4.4(srvx@0.11.9))
+      '@tanstack/start-server-core': 1.146.2(crossws@0.4.4(srvx@0.12.5))
       babel-dead-code-elimination: 1.0.11
       cheerio: 1.1.2
       exsolve: 1.0.8
@@ -8082,13 +8088,13 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/start-server-core@1.146.2(crossws@0.4.4(srvx@0.11.9))':
+  '@tanstack/start-server-core@1.146.2(crossws@0.4.4(srvx@0.12.5))':
     dependencies:
       '@tanstack/history': 1.145.7
       '@tanstack/router-core': 1.146.2
       '@tanstack/start-client-core': 1.146.2
       '@tanstack/start-storage-context': 1.146.2
-      h3-v2: h3@2.0.1-rc.7(crossws@0.4.4(srvx@0.11.9))
+      h3-v2: h3@2.0.1-rc.7(crossws@0.4.4(srvx@0.12.5))
       seroval: 1.4.2
       tiny-invariant: 1.3.3
     transitivePeerDependencies:
@@ -8233,11 +8239,37 @@ snapshots:
     optionalDependencies:
       srvx: 0.11.9
 
+  '@universal-deploy/store@0.2.1(srvx@0.12.5)':
+    dependencies:
+      rou3: 0.8.1
+    optionalDependencies:
+      srvx: 0.12.5
+
   '@universal-deploy/vite@0.1.6(h3@1.15.11)(hono@4.12.5)(srvx@0.11.9)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@universal-deploy/node': 0.1.5(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@universal-deploy/store': 0.2.1(srvx@0.11.9)
       '@universal-middleware/express': 0.4.26(h3@1.15.11)(hono@4.12.5)(srvx@0.11.9)
+      magic-string: 0.30.21
+      rou3: 0.8.1
+    optionalDependencies:
+      vite: 8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@hattip/core'
+      - '@types/express'
+      - '@webroute/route'
+      - elysia
+      - fastify
+      - h3
+      - hono
+      - srvx
+
+  '@universal-deploy/vite@0.1.6(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@universal-deploy/node': 0.1.5(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@universal-deploy/store': 0.2.1(srvx@0.12.5)
+      '@universal-middleware/express': 0.4.26(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)
       magic-string: 0.30.21
       rou3: 0.8.1
     optionalDependencies:
@@ -8262,10 +8294,34 @@ snapshots:
       hono: 4.12.5
       srvx: 0.11.9
 
+  '@universal-middleware/core@0.4.17(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)':
+    dependencies:
+      regexparam: 3.0.0
+      tough-cookie: 6.0.0
+    optionalDependencies:
+      h3: 1.15.11
+      hono: 4.12.5
+      srvx: 0.12.5
+
   '@universal-middleware/express@0.4.26(h3@1.15.11)(hono@4.12.5)(srvx@0.11.9)':
     dependencies:
       '@universal-middleware/core': 0.4.17(h3@1.15.11)(hono@4.12.5)(srvx@0.11.9)
       '@universal-middleware/node': 0.1.0(h3@1.15.11)(hono@4.12.5)(srvx@0.11.9)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@hattip/core'
+      - '@types/express'
+      - '@webroute/route'
+      - elysia
+      - fastify
+      - h3
+      - hono
+      - srvx
+
+  '@universal-middleware/express@0.4.26(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)':
+    dependencies:
+      '@universal-middleware/core': 0.4.17(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)
+      '@universal-middleware/node': 0.1.0(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -8291,9 +8347,37 @@ snapshots:
       - hono
       - srvx
 
+  '@universal-middleware/node@0.1.0(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)':
+    dependencies:
+      '@universal-middleware/core': 0.4.17(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@hattip/core'
+      - '@types/express'
+      - '@webroute/route'
+      - elysia
+      - fastify
+      - h3
+      - hono
+      - srvx
+
   '@universal-middleware/srvx@0.1.3(h3@1.15.11)(hono@4.12.5)(srvx@0.11.9)':
     dependencies:
       '@universal-middleware/core': 0.4.17(h3@1.15.11)(hono@4.12.5)(srvx@0.11.9)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@hattip/core'
+      - '@types/express'
+      - '@webroute/route'
+      - elysia
+      - fastify
+      - h3
+      - hono
+      - srvx
+
+  '@universal-middleware/srvx@0.1.3(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)':
+    dependencies:
+      '@universal-middleware/core': 0.4.17(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -8994,9 +9078,9 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  crossws@0.4.4(srvx@0.11.9):
+  crossws@0.4.4(srvx@0.12.5):
     optionalDependencies:
-      srvx: 0.11.9
+      srvx: 0.12.5
 
   css-select@5.2.2:
     dependencies:
@@ -9679,12 +9763,12 @@ snapshots:
       ufo: 1.6.3
       uncrypto: 0.1.3
 
-  h3@2.0.1-rc.7(crossws@0.4.4(srvx@0.11.9)):
+  h3@2.0.1-rc.7(crossws@0.4.4(srvx@0.12.5)):
     dependencies:
       rou3: 0.7.12
       srvx: 0.10.1
     optionalDependencies:
-      crossws: 0.4.4(srvx@0.11.9)
+      crossws: 0.4.4(srvx@0.12.5)
 
   has-bigints@1.1.0: {}
 
@@ -9786,7 +9870,7 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
-  ipx@3.1.1(@netlify/blobs@10.7.4)(srvx@0.11.9):
+  ipx@3.1.1(@netlify/blobs@10.7.4)(srvx@0.12.5):
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       citty: 0.1.6
@@ -9796,7 +9880,7 @@ snapshots:
       etag: 1.8.1
       h3: 1.15.11
       image-meta: 0.2.2
-      listhen: 1.9.1(srvx@0.11.9)
+      listhen: 1.9.1(srvx@0.12.5)
       ofetch: 1.5.1
       pathe: 2.0.3
       sharp: 0.34.5
@@ -10202,13 +10286,13 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  listhen@1.9.1(srvx@0.11.9):
+  listhen@1.9.1(srvx@0.12.5):
     dependencies:
       '@parcel/watcher': 2.5.6
       '@parcel/watcher-wasm': 2.5.6
       citty: 0.2.2
       consola: 3.4.2
-      crossws: 0.4.4(srvx@0.11.9)
+      crossws: 0.4.4(srvx@0.12.5)
       defu: 6.1.7
       get-port-please: 3.2.0
       h3: 1.15.11
@@ -11210,6 +11294,8 @@ snapshots:
 
   srvx@0.11.9: {}
 
+  srvx@0.12.5: {}
+
   stack-trace@0.0.10: {}
 
   stackback@0.0.2: {}
@@ -11662,6 +11748,39 @@ snapshots:
       '@manypkg/find-root': 3.1.0
       '@universal-deploy/store': 0.2.1(srvx@0.11.9)
       '@universal-deploy/vite': 0.1.6(h3@1.15.11)(hono@4.12.5)(srvx@0.11.9)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vercel/build-utils': 13.14.1
+      '@vercel/nft': 1.5.0(rollup@4.53.5)
+      '@vercel/routing-utils': 6.1.1
+      '@vite-plugin-vercel/schemas': 1.1.0
+      convert-route: 1.1.1
+      fast-glob: 3.3.3
+      magicast: 0.5.2
+      nf3: 0.3.16
+      oxc-transform: 0.120.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      p-limit: 7.3.0
+      rolldown: 1.0.0-rc.15
+      vite: 8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@hattip/core'
+      - '@types/express'
+      - '@webroute/route'
+      - elysia
+      - encoding
+      - fastify
+      - h3
+      - hono
+      - rollup
+      - srvx
+      - supports-color
+
+  vite-plugin-vercel@11.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(h3@1.15.11)(hono@4.12.5)(rollup@4.53.5)(srvx@0.12.5)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      '@manypkg/find-root': 3.1.0
+      '@universal-deploy/store': 0.2.1(srvx@0.12.5)
+      '@universal-deploy/vite': 0.1.6(h3@1.15.11)(hono@4.12.5)(srvx@0.12.5)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vercel/build-utils': 13.14.1
       '@vercel/nft': 1.5.0(rollup@4.53.5)
       '@vercel/routing-utils': 6.1.1


### PR DESCRIPTION
The pinned srvx 0.11 Brotli-compresses every eligible static response at Node's implicit quality 11 — ~157.6 ms vs 2.7 ms per encode on a representative 126 KB bundle; 22.6 → 486.4 req/s end to end. srvx 0.12 encodes at quality 4; its `serveStatic` → `staticMiddleware` rename is already handled by the existing dual-name shim.

`srvx@0.12.5` declares `engines.node >= 20.16.0`; this package declares no engines, and CI's Node 20 satisfies it.

Fixes #34.

First of three related PRs: this → #37 (path-resolution fix) → #35 (opt-in precompression, draft).
