### PR TITLE
fix(adapter-node): root-anchor static-directory resolution

### DIFF
--- a/packages/adapter-node/src/precompress.spec.ts
+++ b/packages/adapter-node/src/precompress.spec.ts
@@ -1,0 +1,95 @@
+import { resolve } from "node:path";
+import type { Environment } from "vite";
+import { describe, expect, it } from "vitest";
+import { resolveStaticDir, resolveStaticHint } from "./vite.js";
+
+/**
+ * Vite 8 leaves `build.outDir` **relative to `config.root`** — in `configResolved`,
+ * per-environment, and in `getTopLevelConfig().environments`. This stub models that
+ * shape; `vite.spec.ts`'s older stub passes absolute outDirs, which Vite never produces.
+ */
+function makeEnv(opts: { root: string; serverOutDir: string; clientOutDir?: string }): Environment {
+  const envs: Record<string, { consumer: string; build: { outDir: string } }> = {
+    ssr: { consumer: "server", build: { outDir: opts.serverOutDir } },
+  };
+  if (opts.clientOutDir !== undefined) {
+    envs.client = { consumer: "client", build: { outDir: opts.clientOutDir } };
+  }
+  return {
+    config: { root: opts.root, build: { outDir: opts.serverOutDir } },
+    getTopLevelConfig: () => ({ environments: envs }),
+  } as unknown as Environment;
+}
+
+/**
+ * A root that is deliberately NOT `process.cwd()`. Anything anchored to the cwd instead
+ * of to `config.root` resolves somewhere else entirely from here.
+ */
+const ROOT = resolve(process.cwd(), "..", "ud-fixture-root");
+
+describe("resolveStaticDir", () => {
+  it("anchors a relative client outDir to config.root, not to process.cwd()", () => {
+    const env = makeEnv({ root: ROOT, serverOutDir: "dist/server", clientOutDir: "dist/client" });
+    expect(resolveStaticDir(env, undefined)).toBe(resolve(ROOT, "dist/client"));
+  });
+
+  it("anchors a relative configured path to config.root", () => {
+    const env = makeEnv({ root: ROOT, serverOutDir: "dist/server" });
+    expect(resolveStaticDir(env, "public-assets")).toBe(resolve(ROOT, "public-assets"));
+  });
+
+  it("returns undefined when static serving is off", () => {
+    const env = makeEnv({ root: ROOT, serverOutDir: "dist/server", clientOutDir: "dist/client" });
+    expect(resolveStaticDir(env, false)).toBeUndefined();
+  });
+
+  it("returns undefined when no client environment exists and nothing is configured", () => {
+    const env = makeEnv({ root: ROOT, serverOutDir: "dist/server" });
+    expect(resolveStaticDir(env, undefined)).toBeUndefined();
+  });
+});
+
+describe("resolveStaticHint with a relative outDir", () => {
+  it("is independent of process.cwd() for a configured path", () => {
+    const env = makeEnv({ root: ROOT, serverOutDir: "dist/server" });
+    expect(resolveStaticHint(env, "dist/client")).toBe("../client");
+  });
+
+  it("is independent of process.cwd() for an auto-detected client outDir", () => {
+    const env = makeEnv({ root: ROOT, serverOutDir: "dist/server", clientOutDir: "dist/client" });
+    expect(resolveStaticHint(env, undefined)).toBe("../client");
+  });
+});
+
+/**
+ * The property U2 exists for: the directory precompression walks and the directory the
+ * built server resolves at runtime are the same path. `serve.ts` computes the latter as
+ * `resolve(<dir of the server entry>, hint)`, which is the server outDir at runtime.
+ */
+describe("walker and server agree on one directory", () => {
+  const cases: Array<[string, string | boolean | undefined, string, string?]> = [
+    ["auto-detected sibling", undefined, "dist/server", "dist/client"],
+    ["configured relative path", "dist/client", "dist/server", "dist/client"],
+    ["configured path outside the build tree", "../shared/static", "dist/server", "dist/client"],
+    ["nested server outDir", undefined, "dist/nested/server", "dist/nested/client"],
+    ["same directory for both", undefined, "dist", "dist"],
+  ];
+
+  for (const [name, configured, serverOutDir, clientOutDir] of cases) {
+    it(name, () => {
+      const env = makeEnv({ root: ROOT, serverOutDir, clientOutDir });
+      const walked = resolveStaticDir(env, configured);
+      const hint = resolveStaticHint(env, configured);
+      expect(hint).not.toBe(false);
+      const servedAtRuntime = resolve(resolve(ROOT, serverOutDir), hint as string);
+      expect(servedAtRuntime).toBe(walked);
+    });
+  }
+
+  it("holds for an absolute configured path, from any runtime location", () => {
+    const abs = resolve(ROOT, "var", "www", "static");
+    const env = makeEnv({ root: ROOT, serverOutDir: "dist/server" });
+    const hint = resolveStaticHint(env, abs);
+    expect(resolve("/somewhere/else/entirely", hint as string)).toBe(resolveStaticDir(env, abs));
+  });
+});

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -22,16 +22,29 @@ function findClientOutDir(env: Environment) {
   return envs.find((e) => e.consumer === "client")?.build.outDir;
 }
 
+/** Absolute path of the directory that will be served, or `undefined` when static
+ *  serving is off. Vite leaves `build.outDir` and a configured path relative to
+ *  `config.root`, so both are anchored to it rather than to `process.cwd()`. */
+export function resolveStaticDir(env: Environment, configured: string | boolean | undefined): string | undefined {
+  if (configured === false) return undefined;
+  const path = typeof configured === "string" ? configured : findClientOutDir(env);
+  if (path === undefined) return undefined;
+  return resolve(env.config.root, path);
+}
+
 /** Compute the value baked into `__UD_STATIC__`. Absolute paths pass through —
  *  the user owns them. Otherwise we emit a path relative to the server entry so
- *  the artifact is portable across filesystems. */
+ *  the artifact is portable across filesystems.
+ *
+ *  Derives from `resolveStaticDir` so the directory precompression walks and the
+ *  directory the server resolves at runtime cannot diverge. */
 export function resolveStaticHint(env: Environment, configured: string | boolean | undefined): string | false {
-  if (configured === false) return false;
   if (typeof configured === "string" && isAbsolute(configured)) return normalizePath(configured);
-  const abs = typeof configured === "string" ? resolve(env.config.root, configured) : findClientOutDir(env);
+  const abs = resolveStaticDir(env, configured);
   if (abs === undefined) return false;
+  const serverOutDir = resolve(env.config.root, env.config.build.outDir);
   // POSIX-style embedded path so a Windows build runs on POSIX too.
-  return normalizePath(relative(env.config.build.outDir, abs)) || ".";
+  return normalizePath(relative(serverOutDir, abs)) || ".";
 }
 
 // Creates a server and listens for connections in Node/Deno/Bun


### PR DESCRIPTION
Vite 8 leaves `build.outDir` relative to `config.root`, but `resolveStaticHint` resolved it through `path.relative` with a relative base — which anchors to `process.cwd()`, wrong on the configured-path branch whenever `cwd !== root` (e.g. `vite build --root <dir>`; the new test is the repro). One root-anchored `resolveStaticDir()` now feeds both the build-time and runtime consumers, so the directory the server resolves cannot diverge from the one the build used. Behavior-preserving wherever `cwd === root`.

Independent of #36. Second of three related PRs: #36 → this → #35 (draft).
