### PR TITLE
fix(node): set NODE_ENV before loading user entry

### DIFF
--- a/.changeset/early-node-env.md
+++ b/.changeset/early-node-env.md
@@ -1,0 +1,5 @@
+---
+"@universal-deploy/node": patch
+---
+
+Set `NODE_ENV` before loading the user server entry.

--- a/packages/adapter-node/src/serve.ts
+++ b/packages/adapter-node/src/serve.ts
@@ -1,6 +1,5 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import userServerEntry from "virtual:ud:catch-all";
 import type { Fetchable } from "@universal-deploy/store";
 import { type FetchHandler, type ServerMiddleware, serve as serveSrvx } from "srvx";
 
@@ -13,6 +12,13 @@ function assertFetchable(mod: unknown, id: string): Fetchable {
 }
 
 async function startServer() {
+  if (!process.env.NODE_ENV) {
+    // @ts-expect-error replaced by node plugin
+    process.env.NODE_ENV = __UD_PROD__ ? "production" : "development";
+  }
+
+  // Dependencies choose their development or production build while the user entry evaluates.
+  const { default: userServerEntry } = await import("virtual:ud:catch-all");
   assertFetchable(userServerEntry, "virtual:ud:catch-all");
   let { static: staticHint } = userServerEntry as unknown as FetchHandler & {
     static?: boolean | string;
@@ -20,11 +26,6 @@ async function startServer() {
 
   // @ts-expect-error replaced by node plugin
   if (staticHint === undefined) staticHint = __UD_STATIC__;
-
-  if (!process.env.NODE_ENV) {
-    // @ts-expect-error replaced by node plugin
-    process.env.NODE_ENV = __UD_PROD__ ? "production" : "development";
-  }
 
   // Resolve a string hint against this module's runtime location — keeps the
   // built artifact portable across filesystems (Docker, deploy targets, …).


### PR DESCRIPTION
## Summary
- initialize `NODE_ENV` before evaluating the virtual user server entry
- preserve explicitly configured `NODE_ENV` values
- dynamically load the user entry so its dependencies choose the correct runtime branch

## Root cause
`@universal-deploy/node` statically imported `virtual:ud:catch-all`, so the user entry and all of its dependencies evaluated before `startServer()` assigned `NODE_ENV`. React chooses its development or production entry points during module evaluation. RSC surfaces the mismatch because the Flight producer and consumer must use matching React protocols.

## Verification
- `@universal-deploy/store` build: exit 0
- `@universal-deploy/node` typecheck: exit 0
- unit tests: exit 0 (2 files, 32 tests)
- adapter build: exit 0
- Biome check: exit 0
- deterministic external-dependency control: published 0.1.9 logs `User dependency evaluated before production NODE_ENV was set` before opening the listener; the fixed build sets production mode first, loads the same dependency, and starts successfully
- RSC example production build: exit 0, all [1/5]–[5/5]
- fixed direct compiled server with `NODE_ENV` absent: `/`, `/todos`, `/suspense`, `/data`, `/client` all HTTP 200
- fixed bare `vike preview` with no downstream preview workaround: same five routes all HTTP 200

The downstream `preview.sh` workaround can be removed once a release containing this fix is consumed.